### PR TITLE
Fix import error in mkvirtenv.py on OSX

### DIFF
--- a/scripts/mkvirtenv.py
+++ b/scripts/mkvirtenv.py
@@ -2,10 +2,10 @@
 
 """Setup a python virtual environment to test holland"""
 
-import sys
-sys.path.insert(0, '.')
-
 import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
 import signal
 import shutil
 import logging


### PR DESCRIPTION
Makes scripts/mkvirtenv.py start_shell() before trying to install_configs().
