### PR TITLE
Fixed a mis-spelling in update for stop-slave bug (LP#810561)

### DIFF
--- a/docs/source/provider_configs/mysqldump.rst
+++ b/docs/source/provider_configs/mysqldump.rst
@@ -71,7 +71,7 @@ mysqldump Provider Configuration [mysqldump]
     allowing data to be spooled from the master.
 
     Note that previous versions of Holland prior to 1.0.6 simply
-    ran a STOP SLAVE instead, which suspends both replicaiton
+    ran a STOP SLAVE instead, which suspends both replication
     threads.
 
 **bin-log-position** = yes | no


### PR DESCRIPTION
Doing it the right way this time. Fix is in my branch. It was a misspelling of 'replication'. Heh, it's one of those days :P
