### PR TITLE
Support for pbzip2

### DIFF
--- a/config/backupsets/examples/mysql-lvm.conf
+++ b/config/backupsets/examples/mysql-lvm.conf
@@ -52,9 +52,9 @@ estimated-size-factor = 1.0
 ## Compression Settings
 [compression]
 
-## compress method: gzip, bzip2, lzop, or xz
+## compress method: gzip, bzip2, pbzip2, lzop, or xz
 ## Which compression method to use, which can be either gzip, bzip2, or lzop.
-## Note that lzop is not often installed by default on many Linux 
+## Note that pbzip2 and lzop are not often installed by default on many Linux 
 ## distributions and may need to be installed separately.
 method              = gzip
 

--- a/config/backupsets/examples/mysqldump.conf
+++ b/config/backupsets/examples/mysqldump.conf
@@ -92,9 +92,9 @@ additional-options  = ""
 ## Compression Settings
 [compression]
 
-## compress method: gzip, bzip2, lzop, or xz
+## compress method: gzip, bzip2, pbzip2, lzop, or xz
 ## Which compression method to use, which can be either gzip, bzip2, or lzop.
-## Note that lzop is not often installed by default on many Linux 
+## Note that pbzip2 and lzop are not often installed by default on many Linux 
 ## distributions and may need to be installed separately.
 method              = gzip
 

--- a/config/providers/mysqldump.conf
+++ b/config/providers/mysqldump.conf
@@ -83,7 +83,7 @@ additional-options  = ""
 ## Compression Settings
 [compression]
 
-## compress method: gzip, bzip2 or lzop
+## compress method: gzip, bzip2, pbzip2, or lzop
 ## Which compression method to use, which can be either gzip, bzip2, or lzop.
 ## Note that lzop is not often installed by default on many Linux 
 ## distributions and may need to be installed separately.

--- a/config/providers/sqlite.conf
+++ b/config/providers/sqlite.conf
@@ -12,7 +12,7 @@ binary = /usr/bin/sqlite3
 ## Compression Settings
 [compression]
 
-## Compress method: gzip, bzip2 or lzop
+## Compress method: gzip, bzip2, pbzip2, or lzop
 ## Which compression method to use, which can be either gzip, bzip2, or lzop.
 ## Note that lzop is not often installed by default on many Linux 
 ## distributions and may need to be installed separately.

--- a/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/plugin/raw/plugin.py
+++ b/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/plugin/raw/plugin.py
@@ -49,7 +49,7 @@ post-args = string(default=None)
 pre-args = string(default=None)
 
 [compression]
-method = option('none', 'gzip', 'pigz', 'bzip2', 'lzop', default='gzip')
+method = option('none', 'gzip', 'pigz', 'bzip2', 'pbzip2', 'lzop', default='gzip')
 level = integer(min=0, max=9, default=1)
 
 [mysql:client]

--- a/plugins/holland.backup.mysqldump/README
+++ b/plugins/holland.backup.mysqldump/README
@@ -6,7 +6,7 @@ skipped by simply not passing them to the --database flags.
 
 Inline-compression of mysqldump output is supported and the default.  By
 default mechanism uses gzip -1 ("--fast") for fast but reasonable compression.
-bzip2, lzop and lzma (vi xz-utils) are also supported.
+bzip2, pbzip2, lzop and lzma (vi xz-utils) are also supported.
 
 For more information please consult the holland manual or visit the holland
 wiki at http://hollandbackup.org.

--- a/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
+++ b/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
@@ -56,7 +56,7 @@ additional-options  = force_list(default=list())
 estimate-method = string(default='plugin')
 
 [compression]
-method        = option('none', 'gzip', 'pigz', 'bzip2', 'lzma', 'lzop', default='gzip')
+method        = option('none', 'gzip', 'pigz', 'bzip2', 'pbzip2', 'lzma', 'lzop', default='gzip')
 inline              = boolean(default=yes)
 level               = integer(min=0, max=9, default=1)
 

--- a/plugins/holland.backup.mysqlhotcopy/holland/backup/mysqlhotcopy.py
+++ b/plugins/holland.backup.mysqlhotcopy/holland/backup/mysqlhotcopy.py
@@ -64,7 +64,7 @@ bin-log-position    = boolean(default=false)
 # Only applicable to certain archive types
 # (e.g. zip only supports 'zlib' internal compression)
 [compression]
-method              = option('none','gzip','pigz','bzip2','lzma','lzop',default='gzip')
+method              = option('none','gzip','pigz','bzip2','pbzip2','lzma','lzop',default='gzip')
 inline              = boolean(default=false)
 level               = integer(default=1,min=0,max=9)
 bin-path            = string(default=None)

--- a/plugins/holland.backup.pgdump/holland/backup/pgdump/interface.py
+++ b/plugins/holland.backup.pgdump/holland/backup/pgdump/interface.py
@@ -34,7 +34,7 @@ role = string(default=None)
 additional-options = string(default=None)
 
 [compression]
-method = option('gzip', 'bzip2', 'lzop', 'lzma', 'pigz', 'none', default='gzip')
+method = option('gzip', 'bzip2', 'pbzip2', 'lzop', 'lzma', 'pigz', 'none', default='gzip')
 level = integer(min=0, default=1)
 
 [pgauth]

--- a/plugins/holland.backup.sqlite/holland/backup/sqlite.py
+++ b/plugins/holland.backup.sqlite/holland/backup/sqlite.py
@@ -15,7 +15,7 @@ databases = force_list(default=list())
 binary = string(default=/usr/bin/sqlite3)
 
 [compression]
-method = option('none', 'gzip', 'pigz', 'bzip2', 'lzop', default='gzip')
+method = option('none', 'gzip', 'pigz', 'bzip2', 'pbzip2', 'lzop', default='gzip')
 inline = boolean(default=yes)
 level = integer(min=0, max=9, default=1)
 """.splitlines()

--- a/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
+++ b/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
@@ -31,7 +31,7 @@ additional-options = force_list(default=list())
 pre-command     = string(default=None)
 
 [compression]
-method          = option('none', 'gzip', 'pigz', 'bzip2', 'lzma', 'lzop', default='gzip')
+method          = option('none', 'gzip', 'pigz', 'bzip2', 'pbzip2', 'lzma', 'lzop', default='gzip')
 inline          = boolean(default=yes)
 level           = integer(min=0, max=9, default=1)
 

--- a/plugins/holland.lib.common/holland/lib/compression.py
+++ b/plugins/holland.lib.common/holland/lib/compression.py
@@ -10,6 +10,7 @@ COMPRESSION_METHODS = {
     'gzip'  : ('gzip', '.gz'),
     'pigz'  : ('pigz', '.gz'),
     'bzip2' : ('bzip2', '.bz2'),
+    'pbzip2': ('pzip2', '.bz2'),
     'lzop'  : ('lzop', '.lzo'),
     'lzma'  : ('xz', '.xz'),
 }
@@ -143,7 +144,7 @@ def stream_info(path, method=None, level=None):
     Arguments:
 
     path    -- Path to file to compress/decompress
-    method  -- Compression method (i.e. 'gzip', 'bzip2', 'lzop')
+    method  -- Compression method (i.e. 'gzip', 'bzip2', 'pbzip2', 'lzop')
     level   -- Compression level (0-9)
     """
     if not method or level == 0:
@@ -168,7 +169,7 @@ def open_stream(path, mode, method=None, level=None, inline=True):
     Arguments:
 
     mode    -- File access mode (i.e. 'r' or 'w')
-    method  -- Compression method (i.e. 'gzip', 'bzip2', 'lzop')
+    method  -- Compression method (i.e. 'gzip', 'bzip2', 'pbzip2', 'lzop')
     level   -- Compression level
     inline  -- Boolean whether to compress inline, or after the file is written.
     """

--- a/test_config/backupsets/traditional.conf
+++ b/test_config/backupsets/traditional.conf
@@ -47,7 +47,7 @@ backup-size-factor   = 1.0
 
 ## Compression settings
 [compression]
-## compress method: gzip, bzip2 or lzop
+## compress method: gzip, bzip2, pbzip2, or lzop
 method              = gzip
 ## where to compress data as it's output
 ## or compress a file at the end

--- a/test_config/providers/mysqldump.conf
+++ b/test_config/providers/mysqldump.conf
@@ -41,7 +41,7 @@ backup-size-factor   = 1.0
 
 # Compression settings
 [compression]
-# compress method: gzip, bzip2 or lzop
+# compress method: gzip, bzip2, pbzip2, or lzop
 method              = gzip
 # where to compress data as it's output
 # or compress a file at the end

--- a/test_suite/tests/providers/mysqldump/all_databases/config/providers/mysqldump.conf
+++ b/test_suite/tests/providers/mysqldump/all_databases/config/providers/mysqldump.conf
@@ -83,9 +83,10 @@ additional-options  = ""
 ## Compression Settings
 [compression]
 
-## compress method: gzip, bzip2 or lzop
-## Which compression method to use, which can be either gzip, bzip2, or lzop.
-## Note that lzop is not often installed by default on many Linux 
+## compress method: gzip, bzip2, pbzip2, or lzop
+## Which compression method to use, which can be either gzip, bzip2, pbzip2, or 
+## lzop.
+## Note that pbzip2 and lzop are not often installed by default on many Linux 
 ## distributions and may need to be installed separately.
 method              = gzip
 

--- a/test_suite/tests/providers/mysqldump/all_databases/config/providers/sqlite.conf
+++ b/test_suite/tests/providers/mysqldump/all_databases/config/providers/sqlite.conf
@@ -5,7 +5,7 @@ binary = /usr/bin/sqlite3
 
 ## Compression settings
 [compression]
-## compress method: gzip, bzip2 or lzop
+## compress method: gzip, bzip2, pbzip2, or lzop
 method              = gzip
 ## where to compress data as it's output
 ## or compress a file at the end


### PR DESCRIPTION
Adds support for using pbzip2 (http://compression.ca/pbzip2/)
pbzip2 has roughly the same commandline interface as bzip2 and pigz, and works perfectly out of the box.

pbzip2 is not usually installed by default and might need to be installed prior to usage.

I'm aware that the new development version of Holland has support for the pbzip2 as an alias to bzip2. I figured this would tide over until v1.1 is released.
