### PR TITLE
Fix typo in compression method list

### DIFF
--- a/plugins/holland.lib.common/holland/lib/compression.py
+++ b/plugins/holland.lib.common/holland/lib/compression.py
@@ -10,7 +10,7 @@ COMPRESSION_METHODS = {
     'gzip'  : ('gzip', '.gz'),
     'pigz'  : ('pigz', '.gz'),
     'bzip2' : ('bzip2', '.bz2'),
-    'pbzip2': ('pzip2', '.bz2'),
+    'pbzip2': ('pbzip2', '.bz2'),
     'lzop'  : ('lzop', '.lzo'),
     'lzma'  : ('xz', '.xz'),
 }


### PR DESCRIPTION
Fixing a typo in the one and only place where spelling pbzip2 correct matters.
Apologies all around.
