### PR TITLE
Minor Update To Provider Config Docs

### DIFF
--- a/docs/source/provider_configs/mysql-lvm.rst
+++ b/docs/source/provider_configs/mysql-lvm.rst
@@ -3,6 +3,14 @@
 MySQL LVM Provider Configuration [mysql-lvm]
 ============================================
 
+Creates an LVM snapshot of a running MySQL instance and performs a 
+binary-based backup with minimal locking. MySQL must be running on an
+LVM volume with reserved space for snapshots. It is highly recommended
+that this volume be separate from the one storing the resulting backups.
+
+[mysql-lvm]
+-----------
+
 **snapshot-size** = <size-in-MB>
 
     The size of the snapshot itself. By default it is 20% of the size of  the 

--- a/docs/source/provider_configs/mysqldump-lvm.rst
+++ b/docs/source/provider_configs/mysqldump-lvm.rst
@@ -1,7 +1,14 @@
 .. _config-mysqldump-lvm:
 
-mysqldump LVM Provider Configuration [mysql-lvm]
-================================================
+mysqldump LVM Provider Configuration [mysqldump-lvm]
+====================================================
+
+Backs up one or more MySQL databases by creating an LVM snapshot and
+then starting a instance of MySQL on top of it to then perform a 
+mysqldump. This effectively produces a non-blocking logical backup.
+
+[mysql-lvm]
+-----------
 
 **snapshot-size** = <size-in-MB>
 

--- a/docs/source/provider_configs/mysqldump.rst
+++ b/docs/source/provider_configs/mysqldump.rst
@@ -3,6 +3,11 @@
 mysqldump Provider Configuration [mysqldump]
 ============================================
 
+Backs up a MySQL database using the mysqldump tool.
+
+[mysqldump]
+-----------
+
 **mysql-binpath** = /path/to/mysql/bin
 
     Defines the location of the MySQL binary utilities. If not provided,

--- a/docs/source/provider_configs/pgdump.rst
+++ b/docs/source/provider_configs/pgdump.rst
@@ -3,6 +3,11 @@
 pgdump Provider Configuration [pgdump]
 ======================================
 
+Backs up a PostgreSQL instance using the pgdump utility.
+
+[pgdump]
+--------
+
 **format** = custom | tar | plain (default: custom)
 
     Defines the --format option for pg_dump.  This defaults to --format=custom.

--- a/docs/source/provider_configs/xtrabackup.rst
+++ b/docs/source/provider_configs/xtrabackup.rst
@@ -3,6 +3,11 @@
 Xtrabackup Provider Configuration [xtrabackup]
 ==============================================
 
+Backs up a MySQL instance using Percona's Xtrabackup tool.
+
+[xtrabackup]
+------------
+
 **global-defaults** = <path> (default: /etc/my.cnf)
 
     The MySQL configuration file for xtrabackup to parse.  This is !include'd


### PR DESCRIPTION
I added a brief summary to each provider configuration, fixed wording on some of the provider config page titles, and added a [provider] header. Previously, the first set of command options were not prefixed by a header and that seemed a tad confusing.

Of note, the mysqldump + LVM provider header has a funky wrap thing when pulling up the page directly. Not sure how best to go about fixing that.

Also of note that, as per the discussion on Holland-Discuss, the use of Provider in the documentation still needs to be removed. This update is not part of that.
