### PR TITLE
This adds a default/sample pgdump config

### DIFF
--- a/test_config/providers/pgdump.conf
+++ b/test_config/providers/pgdump.conf
@@ -1,0 +1,32 @@
+[pgdump]
+## Defines the –format option for pg_dump. 
+## The custom format is required for pg_restore to do
+##  partial restore as well as enabling parallel restores.
+format = custom
+
+## Pass additional options to the pg_dump command
+additional-options = ""
+
+# role = "" # no default
+
+[compression]
+## compress method: gzip, bzip2 or lzop
+## Which compression method to use, which can be either gzip, bzip2, or lzop.
+## Note that lzop is not often installed by default on many Linux 
+## distributions and may need to be installed separately.
+method = gzip
+
+## What compression level to use. Lower numbers mean faster compression, 
+## though also generally a worse compression ratio. Generally, levels 1-3
+## are considered fairly fast and still offer good compression for textual
+## data. Levels above 7 can often cause a larger impact on the system due to
+## needing much more CPU resources. Setting the level to 0 effectively 
+## disables compresion.
+level = 1
+
+[pgauth]
+## For pg_dump authentication
+# username = "" # no default
+# password = "" # no default
+# hostname = "" # no default
+# port = "" # no default


### PR DESCRIPTION
The pgdump provider doesn't have a sample config, this one was build simply with holland mk-config pgdump

But now there will be an easy to find reference that can be packed up and what not.
