### PR TITLE
Remove whitespace in stdout

### DIFF
--- a/plugins/holland.backup.mysqldump/holland/backup/mysqldump/command.py
+++ b/plugins/holland.backup.mysqldump/holland/backup/mysqldump/command.py
@@ -154,6 +154,7 @@ def mysqldump_version(command):
         for line in stdout.splitlines():
             LOG.error("! %s", line)
     try:
+        stdout = stdout.strip()
         return tuple([int(digit) for digit in
                         re.search(r'(\d+)[.](\d+)[.](\d+)', stdout).groups()])
     except AttributeError, exc:


### PR DESCRIPTION
 Remove whitespace/escape chars to prevent potentially zero length tuple return with a stdout.strip() call
