### PR TITLE
Replace defaults in xtrabackup provider to use innobackupex

### DIFF
--- a/config/backupsets/examples/xtrabackup.conf
+++ b/config/backupsets/examples/xtrabackup.conf
@@ -6,7 +6,7 @@ purge-policy = after-backup
 estimated-size-factor = 1.0
 
 [xtrabackup]
-innobackupex = innobackupex-1.5.1
+innobackupex = innobackupex
 stream = yes
 slave-info = no
 

--- a/config/providers/xtrabackup.conf
+++ b/config/providers/xtrabackup.conf
@@ -4,7 +4,7 @@ estimated-size-factor = 1.0
 plugin = xtrabackup
 
 [xtrabackup]
-innobackupex = innobackupex-1.5.1
+innobackupex = innobackupex
 stream = yes
 slave-info = no
 

--- a/docs/source/provider_configs/xtrabackup.rst
+++ b/docs/source/provider_configs/xtrabackup.rst
@@ -13,7 +13,7 @@ Backs up a MySQL instance using Percona's Xtrabackup tool.
     The MySQL configuration file for xtrabackup to parse.  This is !include'd
     into the my.cnf the xtrabackup plugin generates
 
-**innobackupex** = <name> (default: innobackupex-1.5.1)
+**innobackupex** = <name> (default: innobackupex)
 
     The path to the innobackupex script to run. If this is a relative path
     this will be found in holland's environment PATH as configured in

--- a/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
+++ b/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
 CONFIGSPEC = """
 [xtrabackup]
 global-defaults     = string(default='/etc/my.cnf')
-innobackupex        = string(default='innobackupex-1.5.1')
+innobackupex        = string(default='innobackupex')
 ibbackup            = string(default=None)
 stream              = string(default=tar)
 apply-logs          = boolean(default=yes)


### PR DESCRIPTION
- Upstream xtrabackup has deprecated innobackupex-1.5.1 and
  the holland defaults have become stale
