### PR TITLE
rsync plugin + documentation

### DIFF
--- a/config/backupsets/examples/rsync.conf
+++ b/config/backupsets/examples/rsync.conf
@@ -40,9 +40,11 @@ password =
 ## an optional SSH key/identity file to use. Note you can also
 ## put this information into the ~/.ssh/config file of the user
 ## Holland is running as.
+## Be sure to escape spaces.
 keyfile =
 
 ## The directory to backup from, which should be an absolute path.
+## Be sure to escape spaces.
 directory = /
 
 ## Short-hand flags to pass to rsync.

--- a/config/backupsets/examples/rsync.conf
+++ b/config/backupsets/examples/rsync.conf
@@ -11,7 +11,6 @@ plugin = rsync
 backups-to-keep = 5
 auto-purge-failures = yes
 purge-policy = before-backup
-estimated-size-factor = 1.0
 
 # This section defines the configuration options specific to the backup
 # plugin. In other words, the name of this section should match the name
@@ -28,12 +27,20 @@ server =
 
 ## If performing a backup of a remote directory, an optional
 ## username to use. This applies to both SSH and rsync methods.
+## For SSH, you can also palce this in the ~/.ssh/config file
+## of the user Holland is runing as instead.
 username =
 
 ## If performing a backup of a remote directory, an optional
-## password to use. This applies only to the rsync method.
-## If using SSH, you must use SSH keys.
+## password to use. This applies ONLY to the rsync method.
+## If using SSH, you must use SSH keys (see below).
 password =
+
+## If performing a backup of a remote directory using SSH,
+## an optional SSH key/identity file to use. Note you can also
+## put this information into the ~/.ssh/config file of the user
+## Holland is running as.
+keyfile =
 
 ## The directory to backup from, which should be an absolute path.
 directory = /
@@ -47,6 +54,17 @@ flags = -av
 ## reliable, can save lots of space when opting to keep more than
 ## one backup.
 hardlinks = yes
+
+## Whether or not to cross file-systems during the backup. This is
+## often useful for avoiding additional mountpoints without having
+## to use the exclusions list (a prime example is when backing up /).
+one-file-system = no
+
+## If rsync is taking up a lot of bandwidth and/or disk I/O, you can
+## speocify a maximum transfer-rate, specified in units per second.
+## (e.g. "2MB"). See the --max-size and --bwlimit sections of the
+## rsync manpage for more information.
+bandwidth-limit =
 
 ## A list (actually a tuple in Python-speak) of exclusions. These
 ## are files or directories to use in one or more --exclude flags

--- a/config/backupsets/examples/rsync.conf
+++ b/config/backupsets/examples/rsync.conf
@@ -26,8 +26,17 @@ method = local
 ## pull the content from.
 server =
 
+## If performing a backup of a remote directory, an optional
+## username to use. This applies to both SSH and rsync methods.
+username =
+
+## If performing a backup of a remote directory, an optional
+## password to use. This applies only to the rsync method.
+## If using SSH, you must use SSH keys.
+password =
+
 ## The directory to backup from, which should be an absolute path.
-directory = string(default='/')
+directory = /
 
 ## Short-hand flags to pass to rsync.
 flags = -avz

--- a/config/backupsets/examples/rsync.conf
+++ b/config/backupsets/examples/rsync.conf
@@ -39,7 +39,7 @@ password =
 directory = /
 
 ## Short-hand flags to pass to rsync.
-flags = -avz
+flags = -av
 
 ## Whether or not to create hardlinks from the previous backup
 ## if a file has not been changed. This facilitates a kind of

--- a/config/backupsets/examples/rsync.conf
+++ b/config/backupsets/examples/rsync.conf
@@ -1,0 +1,46 @@
+## Holland rsync Example Backup-Set
+##
+## This implements a vanilla backup-set using the rsync provider.
+##
+## Many of these options have global defaults which can be found in the
+## configuration file for the provider (which can be found, by default
+## in /etc/holland/providers).
+
+[holland:backup]
+plugin = rsync
+backups-to-keep = 5
+auto-purge-failures = yes
+purge-policy = before-backup
+estimated-size-factor = 1.0
+
+# This section defines the configuration options specific to the backup
+# plugin. In other words, the name of this section should match the name
+# of the plugin defined above.
+[rsync]
+
+## Copy method which can be local (for a local directory copy),
+## ssh for using secure shell, or rsync for using the rsync protocol.
+method = local
+
+## If performing a backup of a remote directory, which server to
+## pull the content from.
+server =
+
+## The directory to backup from, which should be an absolute path.
+directory = string(default='/')
+
+## Short-hand flags to pass to rsync.
+flags = -avz
+
+## Whether or not to create hardlinks from the previous backup
+## if a file has not been changed. This facilitates a kind of
+## differential backup which, as long as the destination is considered
+## reliable, can save lots of space when opting to keep more than
+## one backup.
+hardlinks = yes
+
+## A list (actually a tuple in Python-speak) of exclusions. These
+## are files or directories to use in one or more --exclude flags
+## passed to rsync.
+## e.g. file1,file2,...
+exclude =

--- a/config/providers/rsync.conf
+++ b/config/providers/rsync.conf
@@ -14,9 +14,15 @@ server =
 username =
 
 ## If performing a backup of a remote directory, an optional
-## password to use. This applies only to the rsync method.
-## If using SSH, you must use SSH keys.
+## password to use. This applies ONLY to the rsync method.
+## If using SSH, you must use SSH keys (see below).
 password =
+
+## If performing a backup of a remote directory using SSH,
+## an optional SSH key/identity file to use. Note you can also
+## put this information into the ~/.ssh/config file of the user
+## Holland is running as.
+keyfile =
 
 # The directory to backup from, which should be an absolute path.
 directory = /
@@ -30,6 +36,17 @@ flags = -av
 # reliable, can save lots of space when opting to keep more than
 # one backup.
 hardlinks = yes
+
+## Whether or not to cross file-systems during the backup. This is
+## often useful for avoiding additional mountpoints without having
+## to use the exclusions list (a prime example is when backing up /).
+one-file-system = no
+
+## If rsync is taking up a lot of bandwidth and/or disk I/O, you can
+## speocify a maximum transfer-rate, specified in units per second.
+## (e.g. "2MB"). See the --max-size and --bwlimit sections of the
+## rsync manpage for more information.
+bandwidth-limit =
 
 # A list (actually a tuple in Python-speak) of exclusions. These
 # are files or directories to use in one or more --exclude flags

--- a/config/providers/rsync.conf
+++ b/config/providers/rsync.conf
@@ -1,0 +1,29 @@
+# Global settings for the rsync Plugin - Requires holland-rsync
+[rsync]
+
+# Copy method which can be local (for a local directory copy),
+# ssh for using secure shell, or rsync for using the rsync protocol.
+method = local
+
+# If performing a backup of a remote directory, which server to
+# pull the content from.
+server =
+
+# The directory to backup from, which should be an absolute path.
+directory = string(default='/')
+
+# Short-hand flags to pass to rsync.
+flags = -avz
+
+# Whether or not to create hardlinks from the previous backup
+# if a file has not been changed. This facilitates a kind of
+# differential backup which, as long as the destination is considered
+# reliable, can save lots of space when opting to keep more than
+# one backup.
+hardlinks = yes
+
+# A list (actually a tuple in Python-speak) of exclusions. These
+# are files or directories to use in one or more --exclude flags
+# passed to rsync.
+# e.g. file1,file2,...
+exclude =

--- a/config/providers/rsync.conf
+++ b/config/providers/rsync.conf
@@ -9,11 +9,20 @@ method = local
 # pull the content from.
 server =
 
+## If performing a backup of a remote directory, an optional
+## username to use. This applies to both SSH and rsync methods.
+username =
+
+## If performing a backup of a remote directory, an optional
+## password to use. This applies only to the rsync method.
+## If using SSH, you must use SSH keys.
+password =
+
 # The directory to backup from, which should be an absolute path.
-directory = string(default='/')
+directory = /
 
 # Short-hand flags to pass to rsync.
-flags = -avz
+flags = -av
 
 # Whether or not to create hardlinks from the previous backup
 # if a file has not been changed. This facilitates a kind of

--- a/config/providers/rsync.conf
+++ b/config/providers/rsync.conf
@@ -35,4 +35,4 @@ hardlinks = yes
 # are files or directories to use in one or more --exclude flags
 # passed to rsync.
 # e.g. file1,file2,...
-exclude =
+exclude = ,

--- a/config/providers/rsync.conf
+++ b/config/providers/rsync.conf
@@ -1,12 +1,12 @@
 # Global settings for the rsync Plugin - Requires holland-rsync
 [rsync]
 
-# Copy method which can be local (for a local directory copy),
-# ssh for using secure shell, or rsync for using the rsync protocol.
+## Copy method which can be local (for a local directory copy),
+## ssh for using secure shell, or rsync for using the rsync protocol.
 method = local
 
-# If performing a backup of a remote directory, which server to
-# pull the content from.
+## If performing a backup of a remote directory, which server to
+## pull the content from.
 server =
 
 ## If performing a backup of a remote directory, an optional
@@ -22,19 +22,21 @@ password =
 ## an optional SSH key/identity file to use. Note you can also
 ## put this information into the ~/.ssh/config file of the user
 ## Holland is running as.
+## Be sure to escape spaces.
 keyfile =
 
-# The directory to backup from, which should be an absolute path.
+## The directory to backup from, which should be an absolute path.
+## Be sure to escape spaces.
 directory = /
 
-# Short-hand flags to pass to rsync.
+## Short-hand flags to pass to rsync.
 flags = -av
 
-# Whether or not to create hardlinks from the previous backup
-# if a file has not been changed. This facilitates a kind of
-# differential backup which, as long as the destination is considered
-# reliable, can save lots of space when opting to keep more than
-# one backup.
+## Whether or not to create hardlinks from the previous backup
+## if a file has not been changed. This facilitates a kind of
+## differential backup which, as long as the destination is considered
+## reliable, can save lots of space when opting to keep more than
+## one backup.
 hardlinks = yes
 
 ## Whether or not to cross file-systems during the backup. This is
@@ -48,8 +50,8 @@ one-file-system = no
 ## rsync manpage for more information.
 bandwidth-limit =
 
-# A list (actually a tuple in Python-speak) of exclusions. These
-# are files or directories to use in one or more --exclude flags
-# passed to rsync.
-# e.g. file1,file2,...
+## A list (actually a tuple in Python-speak) of exclusions. These
+## are files or directories to use in one or more --exclude flags
+## passed to rsync.
+## e.g. file1,file2,...
 exclude = ,

--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -1,5 +1,11 @@
 holland (1.0.8-1) unstable; urgency=low
 
+  * Added rsync
+
+ -- Tim Soderstrom <tim@moocowproductions.org>  Tue, 16 Sept 2015 02:08 +0000
+
+holland (1.0.8-1) unstable; urgency=low
+
   [ Andrew Garner ]
   * New upstream release
 

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -85,3 +85,13 @@ Depends: holland (>= ${binary:Version}),
 description: Holland Postgres Backup Provider Plugin
  This package provides the holland pgdump plugin. 
  
+Package: holland-rsync
+Architecture: all
+Depends: holland (>= ${binary:Version}),
+ holland-common (>= ${binary:Version}),
+ rsync
+ ${misc:Depends},
+ ${python:Depends}
+description: Holland rsync Backup Provider Plugin
+ This package provides the holland rsync plugin. 
+ 

--- a/contrib/debian/holland-rsync.install
+++ b/contrib/debian/holland-rsync.install
@@ -1,0 +1,3 @@
+debian/tmp/usr/lib/python*.*/*-packages/holland.backup.rsync-*.egg-info
+debian/tmp/usr/lib/python*.*/*-packages/holland/backup/rsync/
+config/providers/rsync.conf etc/holland/providers/

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -28,6 +28,7 @@ override_dh_auto_build:
 	dh_auto_build -Dplugins/holland.backup.pgdump
 	dh_auto_build -Dplugins/holland.backup.example
 	dh_auto_build -Dplugins/holland.backup.xtrabackup
+	dh_auto_build -Dplugins/holland.backup.rsync
         
 	# Build the HTML documentation.
 	PYTHONPATH=. sphinx-build -N -q -E -b html docs/source/ docs/html/
@@ -40,6 +41,7 @@ override_dh_auto_install:
 	dh_auto_install -O--buildsystem=python_distutils -Dplugins/holland.backup.mysqldump
 	dh_auto_install -O--buildsystem=python_distutils -Dplugins/holland.backup.mysql_lvm
 	dh_auto_install -O--buildsystem=python_distutils -Dplugins/holland.backup.pgdump
+	dh_auto_install -O--buildsystem=python_distutils -Dplugins/holland.backup.rsync
 	dh_auto_install -O--buildsystem=python_distutils -Dplugins/holland.backup.example
 	dh_auto_install -O--buildsystem=python_distutils -Dplugins/holland.backup.xtrabackup
 	find debian/tmp/ \( -name '*.pth' -or -name 'namespace_packages.txt' \) -delete

--- a/contrib/ubuntu/ubuntu.jaunty/activeplugins
+++ b/contrib/ubuntu/ubuntu.jaunty/activeplugins
@@ -4,4 +4,5 @@ holland.backup.maatkit maatkit
 holland.backup.mysqlhotcopy mysqlhotcopy
 holland.backup.example example
 holland.backup.mysqldump mysqldump
+holland.backup.rsync rsync
 holland.commands.mysql mysqlcmds

--- a/contrib/ubuntu/ubuntu.jaunty/control
+++ b/contrib/ubuntu/ubuntu.jaunty/control
@@ -71,3 +71,9 @@ Depends: holland (>= ${source:Version}), holland-common
 Description: Holland CommVault Command Plugin 
  This package provides the holland commvault command plugin, enabling CommVault
  environments to trigger a backup through holland. 
+
+Package: holland-rsync
+Architecture: any
+Depends: holland (>= ${source:Version}), rsync
+Description: Holland rsync Plugin
+ This package provides the Holland rsync plugin.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig',
         # 'sphinx.ext.viewcode'
         ]
 
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Holland'
-copyright = u'2011-2013, Holland Core Team'
+copyright = u'2011-2015, Holland Core Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -246,8 +246,6 @@ For Example
     after-backup-command = echo ${backupset} completed successfully.  Files are in ${backupdir}
     failed-backup-command = echo "${backupset} failed!" | mail -s "${backupset} backup failed" sysadmins@example.com
 
-
-
 Provider Plugin Configs
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -260,31 +258,14 @@ For advanced users, the defaults for each provider plugin can be changed
 by editing the default configuration file for said provider. These files are
 located in ``/etc/holland/providers`` by default.
 
-MySQL Plugins
-"""""""""""""
-.. toctree::
-    :maxdepth: 1
-
-    mysqldump <provider_plugins/mysqldump>
-    MySQL + LVM <provider_plugins/mysql-lvm>
-    mysqldump + LVM <provider_plugins/mysqldump-lvm>
-    Plugin for Percona XtraBackup <provider_plugins/xtrabackup>
-    MySQL Client Helper Plugin <provider_plugins/mysqlconfig>
-
-Other Plugins
-"""""""""""""
-.. toctree::
-    :maxdepth: 1
-
-    pgdump (PostgreSQL) <provider_plugins/pgdump>
-    rsync <provider_plugins/rsync>
-    Example Plugin <provider_plugins/example>
+For more information on configuring a specific provider, see :doc:`providers`
 
 Helper Plugins
 """"""""""""""
 .. toctree::
     :maxdepth: 1
 
+    MySQL Client Helper Plugin <provider_plugins/mysqlconfig>
     Compression Helper Plugin <provider_plugins/compression>
 
 Backup Set Config Example

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -277,6 +277,7 @@ Other Plugins
     :maxdepth: 1
 
     pgdump (PostgreSQL) <provider_plugins/pgdump>
+    rsync <provider_plugins/rsync>
     Example Plugin <provider_plugins/example>
 
 Helper Plugins

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -135,8 +135,7 @@ backup set configuration file.
 
     [holland:backup]
     plugin = <plugin>
-    backups-to-keep = #
-    estimated-size-factor = #
+    ...
 
 .. _holland-backup-config_options:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Table of Contents
     intro
     commands
     overview
+    providers
     config
 
 Indices and tables
@@ -18,4 +19,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -8,6 +8,19 @@ now able to backup MySQL and PostgreSQL databases. Because Holland is
 plugin-based framework, it can conceivably backup most anything you want
 by whatever means you want.
 
+Overall Concepts
+----------------
+Holland is built around the concept of backup-sets, which define the parameters
+of a backup. This includes global parameters, such as which provider will be
+used and how many backups to keep; as well as provider-specific configuration
+options, such as databases to exclude, user credentials, servers, etc. While
+some providers share similar options with each other, for the most part each
+provider has its own set of configuration options.
+
+Multiple backup-sets can be created and called specifically. Additionally, one
+can define one or more default backup sets to use when running the Holland
+backup command with no additional arguments.
+
 Dependencies
 ------------
 The core Holland framework has the following dependencies (available on any

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -23,9 +23,7 @@ credentials, servers, etc. While some providers share similar options with
 each other, for the most part each provider has its own set of configuration
 options.
 
-Multiple backup-sets can be created and called specifically. Additionally, one
-can define one or more default backup sets to use when running the Holland
-backup command with no additional arguments.
+For more information, see :doc:`overview`
 
 Dependencies
 ------------

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -8,14 +8,20 @@ now able to backup MySQL and PostgreSQL databases. Because Holland is
 plugin-based framework, it can conceivably backup most anything you want
 by whatever means you want.
 
-Overall Concepts
+General Concepts
 ----------------
-Holland is built around the concept of backup-sets, which define the parameters
-of a backup. This includes global parameters, such as which provider will be
-used and how many backups to keep; as well as provider-specific configuration
-options, such as databases to exclude, user credentials, servers, etc. While
-some providers share similar options with each other, for the most part each
-provider has its own set of configuration options.
+Holland is built around the concept of providers and backup-sets.
+
+A provider implements a backup solution. This can range from backing up MySQL
+databases using mysqldump, LVM, or Xtrabackup; to backing up a local or remote
+directory using rsync.
+
+A backup-set defines a backup and includes global parameters, such as which
+provider will be used and how many backups to keep; as well as
+provider-specific configuration options, such as databases to exclude, user
+credentials, servers, etc. While some providers share similar options with
+each other, for the most part each provider has its own set of configuration
+options.
 
 Multiple backup-sets can be created and called specifically. Additionally, one
 can define one or more default backup sets to use when running the Holland

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,10 +1,10 @@
 Introduction to Holland
 =======================
 
-Holland is an Open Source backup framework originally developed by Rackspace 
+Holland is an Open Source backup framework originally developed by Rackspace
 and written in Python. The original intent was to offer more reliability and
 flexilibity when backing up MySQL databases, though the current version is
-now able to backup MySQL and PostgreSQL databases. Because Holland is 
+now able to backup MySQL and PostgreSQL databases. Because Holland is
 plugin-based framework, it can conceivably backup most anything you want
 by whatever means you want.
 
@@ -23,7 +23,7 @@ MySQL based plugins additional require the MySQLdb python connector:
 
 For Red-Hat Enterprise Linux 5, all dependencies are available directly from
 the base channels. For Red-Hat Enterprise Linux 4, EPEL is required for
-python-setuptools. 
+python-setuptools.
 
 Note that other plugins may have additional dependency requirements.
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1,34 +1,31 @@
 Usage and Implementation Overview
 =================================
 
-Because Holland is very pluggable, it may first seem a bit confusing when
-it comes to configuring Holland to do something useful. Out of the box,
-Holland is designed to backup MySQL databases using the mysqldump provider.
-This is the simplest setup, and may be sufficient for most people. However, 
-others may wish to have more fine-grained control over their backups and/or 
-use another method other than mysqldump.
-
-For instance, one can configure a backup set to backup certain databases
-using mysqldump, others using the mysql-lvm plugins etc. All this is done
-by a mix of plugins (sometimes called providers) and backup-sets.
+Holland is built around the concept of plugins, though for the end user, most
+of these plugins will be in the form of backup providers and their helper
+plugins. These are configured by way of a backup-set which defines the
+characteristics of a particular backup.
 
 Backup-Sets
 ^^^^^^^^^^^
+A backup-set is compromised of global, provider, and helper plugin
+configuration options which make up a particular backup. For instance, once
+might want to backup a handful of MySQL databases using some specific
+mysqldump settings; while backing up another set of MySQL databases using
+different settings. To do this, one might create two backups sets for each
+scenario.
 
-Each backup-set implements a backup plugin (provider) and often some helper
-plugins for things such as compression. Plugins come with a set of defaults
-such that only values that need to be overridden need to be specified, 
-although it is perfectly acceptable to specify options that are already 
-default - one would merely be stating the obvious. Doing so would also 
-make sure future changes to the defaults in Holland do not impact existing
-backup-sets.
+Most plugins come with a set of defaults such that only values that need to be
+overridden need to be specified in a backup-set if desired. Such defaults
+can be modified on a global basis by editing the global provider configuration
+files (see below).
 
 Provider Plugins
 ^^^^^^^^^^^^^^^^
 
 Provider plugins provide a backup service for use in a backup set. They
 are the interface between Holland and the method of backing up data.
-As of Holland 1.0.8, there are 5 providers included with Holland:
+As of Holland |version|, there are 5 providers included with Holland:
 
 * mysqldump
 
@@ -36,7 +33,7 @@ As of Holland 1.0.8, there are 5 providers included with Holland:
 
 * MySQL + LVM
 
-    Backup MySQL databases using LVM snapshots which allows for near lockless 
+    Backup MySQL databases using LVM snapshots which allows for near lockless
     or fully lockless (when transactional engines are used) backups. MySQL
     must be running on an LVM volume with sufficient free extents to store
     a working snapshot. It is also extremely ill-advised to store the backup
@@ -45,7 +42,7 @@ As of Holland 1.0.8, there are 5 providers included with Holland:
 * Support for `Percona XtraBackup <http://www.percona.com/software/percona-xtrabackup>`_
 
     .. versionadded:: 1.0.8
-    
+
     Backup MySQL databases using `Percona XtraBackup <http://www.percona.com/software/percona-xtrabackup>`_.
     This provides a near lockless backup when using the InnoDB storage engine
     while also providing a mysqlhotcopy style backup for MyISAM tables.
@@ -58,8 +55,8 @@ As of Holland 1.0.8, there are 5 providers included with Holland:
 
     This is used solely as a template for designing providers. It otherwise
     does nothing.
-    
+
 As Holland is a framework, it can actually backup most anything as long
 as there is a provider plugin for it. This includes things that have
-nothing to do with databases. The idea is to present an easy to use 
+nothing to do with databases. The idea is to present an easy to use
 and clear method of backing up and restoring backups no matter the source.

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -6,57 +6,48 @@ of these plugins will be in the form of backup providers and their helper
 plugins. These are configured by way of a backup-set which defines the
 characteristics of a particular backup.
 
-Backup-Sets
-^^^^^^^^^^^
-A backup-set is compromised of global, provider, and helper plugin
-configuration options which make up a particular backup. For instance, once
-might want to backup a handful of MySQL databases using some specific
-mysqldump settings; while backing up another set of MySQL databases using
-different settings. To do this, one might create two backups sets for each
-scenario.
-
-Most plugins come with a set of defaults such that only values that need to be
-overridden need to be specified in a backup-set if desired. Such defaults
-can be modified on a global basis by editing the global provider configuration
-files (see below).
+.. _overview-providers:
 
 Provider Plugins
 ^^^^^^^^^^^^^^^^
 
 Provider plugins provide a backup service for use in a backup set. They
 are the interface between Holland and the method of backing up data.
-As of Holland |version|, there are 5 providers included with Holland:
-
-* mysqldump
-
-    Uses the ``mysqldump`` utility to backup MySQL databases.
-
-* MySQL + LVM
-
-    Backup MySQL databases using LVM snapshots which allows for near lockless
-    or fully lockless (when transactional engines are used) backups. MySQL
-    must be running on an LVM volume with sufficient free extents to store
-    a working snapshot. It is also extremely ill-advised to store the backup
-    on the same volume as MySQL.
-
-* Support for `Percona XtraBackup <http://www.percona.com/software/percona-xtrabackup>`_
-
-    .. versionadded:: 1.0.8
-
-    Backup MySQL databases using `Percona XtraBackup <http://www.percona.com/software/percona-xtrabackup>`_.
-    This provides a near lockless backup when using the InnoDB storage engine
-    while also providing a mysqlhotcopy style backup for MyISAM tables.
-
-* pgdump
-
-    Backup PostgreSQL databases using the ``pgdump`` utility.
-
-* Example
-
-    This is used solely as a template for designing providers. It otherwise
-    does nothing.
 
 As Holland is a framework, it can actually backup most anything as long
-as there is a provider plugin for it. This includes things that have
-nothing to do with databases. The idea is to present an easy to use
+as there is a provider plugin for it. The idea is to present an easy to use
 and clear method of backing up and restoring backups no matter the source.
+
+Backup-Sets
+^^^^^^^^^^^
+A backup-set is compromised of global, provider, and helper plugin
+configuration options which make up a particular backup. These options are
+stored in a simple INI-based configuration file. The name of the configuration
+file corresponds to the name of the backup set.
+
+For instance, once might want to backup a handful of MySQL databases using
+some specific mysqldump settings; while backing up another set of MySQL
+databases using different settings. To do this, one might create two backups
+sets for each scenario.
+
+Most plugins come with a set of defaults such that only values that need to be
+overridden need to be specified in a backup-set if desired. Such defaults
+can be modified on a global basis by editing the global provider configuration
+files (see :ref:`overview-providers`).
+
+Backups
+^^^^^^^
+Backups are of course the end product of the whole exercise. Holland stores
+these under the ``backup_direcotry`` defined in the main ``holland.conf``
+configuration file. The default location is usually ``/var/spool/holland``.
+Under this directory there is a sub-directory for individual backup-sets.
+Under those directories are the actual backup directories. The name of each
+backup directory is the timestamp of when it was run. As of Holland 1.0.8
+or newer, there are also ``newest`` and ``oldest`` directories which,
+perhaps unsurprisingly, correspond to the newest and oldest backup.
+
+As implied, there can be multiple backups under a backup-set. The scheduling
+of running backups is up to you. Holland does not care how often backups are
+run - it only cares about how many backups to keep. This, with the help of
+services like ``cron``, one can be fairly flexible about the scheduling and
+frequency of backups.

--- a/docs/source/provider_plugins/compression.rst
+++ b/docs/source/provider_plugins/compression.rst
@@ -1,5 +1,5 @@
 [compression]
--------------
+_____________
 
 Specify various compression settings, such as compression utility,
 compression level, etc.

--- a/docs/source/provider_plugins/databasefiltering.rst
+++ b/docs/source/provider_plugins/databasefiltering.rst
@@ -1,5 +1,5 @@
 Database and Table filtering
-----------------------------
+____________________________
 
 **databases** = <glob>
 
@@ -9,12 +9,12 @@ Database and Table filtering
 
 **exclude-tables** = <glob>
 
-The above options accepts GLOBs in comma-separated lists. Multiple 
-filtering options can be specified. When filtering on tables, be sure to 
-include both the database and table name. 
+The above options accepts GLOBs in comma-separated lists. Multiple
+filtering options can be specified. When filtering on tables, be sure to
+include both the database and table name.
 
-Be careful with quotes. Normally these are not needed, but  when quotes 
-are necessary, be sure to only quote each filtering statement, as 
+Be careful with quotes. Normally these are not needed, but  when quotes
+are necessary, be sure to only quote each filtering statement, as
 opposed to putting quotes around all statements.
 
 Below are a few examples of how these can be applied:
@@ -26,7 +26,7 @@ Default (backup everything)::
 
 Using database inclusion and exclusions::
 
- databases = drupal*, smf_forum, 
+ databases = drupal*, smf_forum,
  exclude-databases = drupal5
 
 Including Tables::
@@ -36,4 +36,3 @@ Including Tables::
 Excluding Tables::
 
   exclude-tables = mydb.uselesstable1, x_cart.*, *.sessions
-

--- a/docs/source/provider_plugins/databasefiltering.rst
+++ b/docs/source/provider_plugins/databasefiltering.rst
@@ -1,5 +1,5 @@
 Database and Table filtering
-____________________________
+""""""""""""""""""""""""""""
 
 **databases** = <glob>
 

--- a/docs/source/provider_plugins/example.rst
+++ b/docs/source/provider_plugins/example.rst
@@ -1,8 +1,8 @@
 .. _config-example:
 
-Example Provider Configuration [example]
-========================================
+Example
+=======
 
 There are currently no configuration options for the example provider.
-It is provided as a skeleton for anyone wishing to write their own 
+It is provided as a skeleton for anyone wishing to write their own
 provider plugin.

--- a/docs/source/provider_plugins/mysql-lvm.rst
+++ b/docs/source/provider_plugins/mysql-lvm.rst
@@ -1,37 +1,40 @@
 .. _config-mysql-lvm:
 
-MySQL LVM Provider Configuration [mysql-lvm]
-============================================
+MySQL LVM
+=========
 
-Creates an LVM snapshot of a running MySQL instance and performs a 
+Creates an LVM snapshot of a running MySQL instance and performs a
 binary-based backup with minimal locking. MySQL must be running on an
 LVM volume with reserved space for snapshots. It is highly recommended
 that this volume be separate from the one storing the resulting backups.
 
+Configuration
+-------------
+
 [mysql-lvm]
------------
+___________
 
 **snapshot-size** = <size-in-MB>
 
-    The size of the snapshot itself. By default it is 20% of the size of  the 
-    MySQL LVM mount or the remaining free-space in the Volume Group (if there 
-    is less than 20% available) up to 15GB. If snapshot-size is defined, the 
+    The size of the snapshot itself. By default it is 20% of the size of  the
+    MySQL LVM mount or the remaining free-space in the Volume Group (if there
+    is less than 20% available) up to 15GB. If snapshot-size is defined, the
     number represents the size of the snapshot in megabytes.
 
 **snapshot-name** = <name>
 
-    The name of the snapshot, the default being the name of the MySQL LVM 
+    The name of the snapshot, the default being the name of the MySQL LVM
     volume + "_snapshot" (ie Storage-MySQL_snapshot)
-    
-**snapshot-mountpoint** = <path>    
-    
-    Where to mount the snapshot. By default a randomly generated directory 
+
+**snapshot-mountpoint** = <path>
+
+    Where to mount the snapshot. By default a randomly generated directory
     under /tmp is used.
 
 **innodb-recovery** = yes | no (default: no)
 
-    Whether or not to run an InnoDB recovery operation. This avoids needing 
-    to do so during a restore, though will make the backup process itself 
+    Whether or not to run an InnoDB recovery operation. This avoids needing
+    to do so during a restore, though will make the backup process itself
     take longer.
 
 **force-innodb-backup** = yes | no (default: no)
@@ -41,26 +44,26 @@ that this volume be separate from the one storing the resulting backups.
     on entirely separate logical volumes.
 
 **lock-tables** = yes | no (default: yes)
-    
+
     Whether or not to run a FLUSH TABLES WITH READ LOCK to grab various
     bits of information (such as the binary log name and position). Disabling
     this requires that binary logging is disabled and InnoDB is being used
     exclusively. Otherwise, it is possible that the backup could contain
     crashed tables.
-    
+
 **extra-flush-tables** = yes | no (default: yes)
-    
-    Whether or not to run a FLUSH TABLES before running the full 
+
+    Whether or not to run a FLUSH TABLES before running the full
     FLUSH TABLES WITH READ LOCK. Should make the FLUSH TABLES WITH READ LOCK
     operation a bit faster.
 
 
 [tar]
------
+_____
 
 **exclude** = pattern[, pattern...]
 
-Patterns to exclude from archive.   These should be relative paths and are almost 
+Patterns to exclude from archive.   These should be relative paths and are almost
 always relative to the mysql data directory.  For instance to exclude binary logs
 in the data directory from the backup you might specify:
 exclude = ./bin-log.*, mysql.sock
@@ -69,7 +72,7 @@ exclude = ./bin-log.*, mysql.sock
 
 Additional arguments to append to the tar commandline before the backup path is specified.
 This should be the full string as you might specify on the commandline. Shell globbing is not
-supported.  
+supported.
 
 For instance you
 might add the /etc/my.cnf to the tar archive via:

--- a/docs/source/provider_plugins/mysqlconfig.rst
+++ b/docs/source/provider_plugins/mysqlconfig.rst
@@ -1,5 +1,5 @@
 MySQL connection info [mysql:client]
-------------------------------------
+____________________________________
 
 These are optional and, if left undefined, Holland will try to login using
 the standard .my.cnf conventions.

--- a/docs/source/provider_plugins/mysqldump-lvm.rst
+++ b/docs/source/provider_plugins/mysqldump-lvm.rst
@@ -1,14 +1,17 @@
 .. _config-mysqldump-lvm:
 
-mysqldump LVM Provider Configuration [mysqldump-lvm]
-====================================================
+mysqldump + LVM
+===============
 
 Backs up one or more MySQL databases by creating an LVM snapshot and
 then starting a instance of MySQL on top of it to then perform a
 mysqldump. This effectively produces a non-blocking logical backup.
 
+Configuration
+-------------
+
 [mysql-lvm]
------------
+___________
 
 **snapshot-size** = <size-in-MB>
 
@@ -48,7 +51,7 @@ mysqldump. This effectively produces a non-blocking logical backup.
     operation a bit faster.
 
 [mysqld]
---------
+________
 
 **mysqld-exe** = <path>[, <path>...] (default: mysqld in PATH, /usr/libexec/mysqld)
 
@@ -68,7 +71,7 @@ mysqldump. This effectively produces a non-blocking logical backup.
     Path to the --tmpdir that mysqld should use.
 
 [mysqldump]
------------
+___________
 
 mysqldump-lvm supports almost all of the options from the mysqldump plugin.
 --master-data is not supported, as the mysqld process will not read binary

--- a/docs/source/provider_plugins/mysqldump.rst
+++ b/docs/source/provider_plugins/mysqldump.rst
@@ -1,12 +1,23 @@
 .. _config-mysqldump:
 
-mysqldump Provider Configuration [mysqldump]
-============================================
+mysqldump
+=========
 
-Backs up one or more MySQL databases using the mysqldump tool.
+Uses the ``mysqldump`` utility to backup one or more MySQL databases using a
+logical backup (aka a flat SQL file). Many options are available for which
+databases should be backed up and how.
+
+``mysqldump`` style backups tend to result in smaller
+backups, at least when dealing with databases which have few, if any,
+binary objects (BLOBs). That said, ``mysqldump`` tends to be slow and require
+more system resources than the other options. Restores likewise can take a
+very long time for large databases.
+
+Configuration
+-------------
 
 [mysqldump]
------------
+___________
 
 **mysql-binpath** = /path/to/mysql/bin
 
@@ -142,7 +153,7 @@ Backs up one or more MySQL databases using the mysqldump tool.
     be difficult if multiple databases are defined in the backup set.
 
     When backing up all databases within a single file, the backup file
-    will be named ``all_databases.sql``. If compression is used, the 
+    will be named ``all_databases.sql``. If compression is used, the
     compression extension will be appended to the filename
     (e.g. ``all_databases.sql.gz``).
 
@@ -172,12 +183,7 @@ Backs up one or more MySQL databases using the mysqldump tool.
     information schema is used, which may be slow particularly for a large
     number of tables.
 
-Database and Table filtering
-----------------------------
-.. toctree::
-    :maxdepth: 1
-
-    databasefiltering
+.. include:: databasefiltering.rst
 
 .. include:: compression.rst
 

--- a/docs/source/provider_plugins/pgdump.rst
+++ b/docs/source/provider_plugins/pgdump.rst
@@ -1,12 +1,15 @@
 .. _config-pgdump:
 
-pgdump Provider Configuration [pgdump]
-======================================
+pgdump
+======
 
 Backs up a PostgreSQL instance using the pgdump utility.
 
+Configuration
+-------------
+
 [pgdump]
---------
+________
 
 **format** = custom | tar | plain (default: custom)
 
@@ -21,7 +24,7 @@ Backs up a PostgreSQL instance using the pgdump utility.
 .. include:: compression.rst
 
 [pgauth]
---------
+________
 
 **username** = <name>
 

--- a/docs/source/provider_plugins/rsync.rst
+++ b/docs/source/provider_plugins/rsync.rst
@@ -1,0 +1,80 @@
+.. _config-rsync:
+
+rsync Provider Configuration [rsync]
+======================================
+
+Uses rsync to backup a local or remote directory, optionally by making use of
+hardlinks as a means to provide a sort of differential backup.
+
+[rsync]
+-------
+
+**method** = local | rsync | ssh (default: local)
+
+    Method to sync with which can be local (for a local directory copy),
+    ssh for using secure shell, or rsync for using the rsync protocol.
+
+**server** = <hostname or IP address> (default: none)
+
+    If performing a backup of a remote directory, which server to
+    pull the content from.
+
+**port** = <TCP port> (default: none)
+
+    An optional setting to specify a custom port to connect to when using the
+    rsync or SSH methods.
+
+**username** = <username> (default: none)
+
+    An optional setting to specify a username to connect with when using the
+    rsync or SSH methods.
+
+**keyfile** = <path> (default: none)
+
+    An optional setting to specify an SSH keyfile to use with the SSH method.
+    This should be an absolute path. Be sure to escape spaces.
+    (e.g. ``/directory/with\ spaces``)
+
+**password** = <cleartext password> (default: none)
+
+    An option setting to specify an rsync password to use with the rsync method.
+    This password is in cleartext so be sure to make the appropriate security
+    precautions.
+
+**directory** = <path> (default: /)
+
+    The path of the source directory to backup from. Be sure to escape spaces.
+    (e.g. ``/directory/with\ spaces``)
+
+**flags** = <rsync short-flags> (default: -av)
+
+    The short-flags to pass to rsync. See the rsync manpage for a full listing,
+    though for the most part, ``-av`` works well for local backups and ``-avz``
+    for remote backups (``z`` being for compression to save on bandwidth).
+
+**hardlinks** = <yes | no> (default: yes)
+
+    Whether or not to create hardlinks from the previous backup if a file has
+    not been changed. This facilitates a kind of differential backup which,
+    as long as the destination is considered reliable, can save lots of space
+    when opting to keep more than one backup.
+
+**one-file-system** = <yes | no> (default: no)
+
+    Whether or not to cross file-systems during the backup. This is often
+    useful for avoiding additional mountpoints without having to use the
+    exclusions list. A common case where this is useful is when backing up /,
+    as this setting would cause /proc, /sys and any mounted disks to be skipped.
+
+**bandwidth-limit** = <size with units> (default: none)
+
+    To keep rsync from taking up a lot of bandwidth and/or disk I/O, speocify
+    a maximum transfer-rate, specified in units per second. (e.g. "2MB").
+    See the --max-size and --bwlimit sections of the rsync manpage for more
+    information.
+
+**exclude** = <comma seperated list> (default: none)
+
+    A list (actually a tuple in Python-speak) of exclusions. These are files or
+    directories to use in one or more --exclude flags passed to rsync.
+    e.g. ``file1,file2,...``

--- a/docs/source/provider_plugins/rsync.rst
+++ b/docs/source/provider_plugins/rsync.rst
@@ -1,13 +1,16 @@
 .. _config-rsync:
 
-rsync Provider Configuration [rsync]
-======================================
+rsync
+=====
 
-Uses rsync to backup a local or remote directory, optionally by making use of
+Uses ``rsync`` to backup a local or remote directory, optionally by making use of
 hardlinks as a means to provide a sort of differential backup.
 
+Configuration
+-------------
+
 [rsync]
--------
+_______
 
 **method** = local | rsync | ssh (default: local)
 

--- a/docs/source/provider_plugins/xtrabackup.rst
+++ b/docs/source/provider_plugins/xtrabackup.rst
@@ -1,7 +1,7 @@
 .. _config-xtrabackup:
 
-Holland Plugin for Percona XtraBackup Configuration [xtrabackup]
-=========================================================================
+Xtrabackup
+==========
 
 Backup a MySQL instance using `Percona XtraBackup`_.
 
@@ -10,8 +10,11 @@ Backup a MySQL instance using `Percona XtraBackup`_.
    trademark to imply a relationship with, or endorsement or sponsorship
    of the Holland Project by Percona.
 
+Configuration
+-------------
+
 [xtrabackup]
-------------
+____________
 
 **global-defaults** = <path> (default: /etc/my.cnf)
 
@@ -23,23 +26,23 @@ Backup a MySQL instance using `Percona XtraBackup`_.
     The path to the innobackupex script to run. If this is a relative path
     this will be found in holland's environment PATH as configured in
     /etc/holland/holland.conf.
-    
-    
-**ibbackup** = <name>    
-    
+
+
+**ibbackup** = <name>
+
     The path to the ibbackup command to use.  By default, no --ibbackup option
     is pass to the innobackupex script.  Usually innobackupex will detect this
     by itself and this should not need to be set.
 
 **stream** = tar|xbstream|yes|no (default: tar)
 
-    Whether to generate a streaming backup. 
+    Whether to generate a streaming backup.
 
 .. versionchanged:: 1.0.8
    'tar' and 'xbstream' are now valid options.  The old stream = yes is
    now equivalent to stream = tar and stream = no disables streaming
    entirely and will result in a normal directory copy with xtrabackup
-       
+
 
 **apply-logs** = yes | no (default: yes)
 
@@ -52,11 +55,11 @@ Backup a MySQL instance using `Percona XtraBackup`_.
     .. versionadded:: 1.0.8
 
 **slave-info** = yes | no (default: yes)
-    
+
     Whether to enable the --slave-info innobackupex option
 
 **safe-slave-backup** = yes | no (default: yes)
-    
+
     Whether to enable the --safe-slave-backup innobackupex option.
 
 **no-lock** = yes | no (default: no)

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -28,3 +28,4 @@ These are providers which do something other than backup a MySQL database.
 
     provider_plugins/pgdump
     provider_plugins/rsync
+    provider_plugins/example

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -1,0 +1,30 @@
+Backup Providers
+================
+
+Here is an overview the providers included with Holland. For specific
+configuration details on how to use these with a backup-set, see :doc:`config`
+
+MySQL Providers
+^^^^^^^^^^^^^^^
+
+These providers are for backing up MySQL databases using various means. Since
+there are so many providers specific to MySQL, these are given their own
+section.
+
+.. toctree::
+    :maxdepth: 1
+
+    provider_plugins/mysqldump
+    provider_plugins/mysql-lvm
+    provider_plugins/mysqldump-lvm
+    provider_plugins/xtrabackup
+
+Other Providers
+^^^^^^^^^^^^^^^
+These are providers which do something other than backup a MySQL database.
+
+.. toctree::
+    :maxdepth: 1
+
+    provider_plugins/pgdump
+    provider_plugins/rsync

--- a/holland/core/backup/base.py
+++ b/holland/core/backup/base.py
@@ -184,7 +184,7 @@ class BackupRunner(object):
             if available_bytes > required_bytes:
                 break
         else:
-            LOG.info("Purging would only recover an additional %s", 
+            LOG.info("Purging would only recover an additional %s",
                      format_bytes(sum(to_purge.values())))
             LOG.info("Only %s total would be available, but the current "
                      "backup requires %s",
@@ -211,29 +211,30 @@ class BackupRunner(object):
         available_bytes = disk_free(spool_entry.path)
 
         estimated_bytes_required = plugin.estimate_backup_size()
-        LOG.info("Estimated Backup Size: %s",
-                 format_bytes(estimated_bytes_required))
+        if estimated_bytes_required is not None:
+            LOG.info("Estimated Backup Size: %s",
+                     format_bytes(estimated_bytes_required))
 
-        config = plugin.config['holland:backup']
-        adjustment_factor = config['estimated-size-factor']
-        adjusted_bytes_required = (estimated_bytes_required*adjustment_factor)
+            config = plugin.config['holland:backup']
+            adjustment_factor = config['estimated-size-factor']
+            adjusted_bytes_required = (estimated_bytes_required*adjustment_factor)
 
-        if adjusted_bytes_required != estimated_bytes_required:
-            LOG.info("Adjusting estimated size by %.2f to %s",
-                     adjustment_factor,
-                     format_bytes(adjusted_bytes_required))
+            if adjusted_bytes_required != estimated_bytes_required:
+                LOG.info("Adjusting estimated size by %.2f to %s",
+                         adjustment_factor,
+                         format_bytes(adjusted_bytes_required))
 
-        if available_bytes <= adjusted_bytes_required:
-            if not (config['purge-on-demand'] and 
-                    self.free_required_space(spool_entry.backupset,
-                                         adjusted_bytes_required,
-                                         dry_run)):
-                msg = ("Insufficient Disk Space. %s required, "
-                       "but only %s available on %s") % (
-                       format_bytes(adjusted_bytes_required),
-                       format_bytes(available_bytes),
-                       self.spool.path)
-                LOG.error(msg)
-                if not dry_run:
-                    raise BackupError(msg)
+            if available_bytes <= adjusted_bytes_required:
+                if not (config['purge-on-demand'] and
+                        self.free_required_space(spool_entry.backupset,
+                                             adjusted_bytes_required,
+                                             dry_run)):
+                    msg = ("Insufficient Disk Space. %s required, "
+                           "but only %s available on %s") % (
+                           format_bytes(adjusted_bytes_required),
+                           format_bytes(available_bytes),
+                           self.spool.path)
+                    LOG.error(msg)
+                    if not dry_run:
+                        raise BackupError(msg)
         return estimated_bytes_required

--- a/plugins/ACTIVE
+++ b/plugins/ACTIVE
@@ -7,3 +7,4 @@ holland.backup.mysqldump
 holland.backup.mysqlhotcopy
 holland.backup.mysql_lvm
 holland.backup.xtrabackup
+holland.backup.rsync

--- a/plugins/holland.backup.rsync/README
+++ b/plugins/holland.backup.rsync/README
@@ -1,0 +1,6 @@
+This plugin acts as a front-end to facilitate both local and remote
+backups of files and directories using rsync. Currently local copy,
+as well as SSH and RSYNC remote methods are supported. Additionally,
+hard-linking is supported across backups meaning that, if a file has
+not changed since the last time Holland was run, a hardlink from the
+previous backup is used instead of re-copying the file.

--- a/plugins/holland.backup.rsync/TODO
+++ b/plugins/holland.backup.rsync/TODO
@@ -2,8 +2,6 @@ TODO
 
   * Add license info (GPLv2)
 
-  * Impelment an actual dry-run using --dry-run
-
   * Estimate Backup Size busted
     How to calculate size for remote hosts (--dry-run?) and what about cases
     where --one-file-system is used? Plus the old way was expensive for large

--- a/plugins/holland.backup.rsync/TODO
+++ b/plugins/holland.backup.rsync/TODO
@@ -1,7 +1,6 @@
 TODO
 
-  * Ports feature does not work
-    Running into an odd scaping issue that is making that difficult currently.
+  * Impelment an actual dry-run using --dry-run
 
   * Estimate Backup Size busted
     How to calculate size for remote hosts (--dry-run?) and what about cases

--- a/plugins/holland.backup.rsync/TODO
+++ b/plugins/holland.backup.rsync/TODO
@@ -1,0 +1,4 @@
+* Implement a way to specify additional options (such as --bwlimit)
+
+Either by exposing the flags as config variables or providing a sort
+of extra-args for putting flags in manually (or both).

--- a/plugins/holland.backup.rsync/TODO
+++ b/plugins/holland.backup.rsync/TODO
@@ -1,6 +1,9 @@
-* Implement a way to specify additional options (such as --bwlimit)
+TODO
 
-Either by exposing the flags as config variables or providing a sort
-of extra-args for putting flags in manually (or both).
+  * Ports feature does not work
+    Running into an odd scaping issue that is making that difficult currently.
 
-* Username/Password is missing
+  * Estimate Backup Size busted
+    How to calculate size for remote hosts (--dry-run?) and what about cases
+    where --one-file-system is used? Plus the old way was expensive for large
+    files/directories.

--- a/plugins/holland.backup.rsync/TODO
+++ b/plugins/holland.backup.rsync/TODO
@@ -1,5 +1,7 @@
 TODO
 
+  * Add license info (GPLv2)
+
   * Impelment an actual dry-run using --dry-run
 
   * Estimate Backup Size busted

--- a/plugins/holland.backup.rsync/TODO
+++ b/plugins/holland.backup.rsync/TODO
@@ -2,3 +2,5 @@
 
 Either by exposing the flags as config variables or providing a sort
 of extra-args for putting flags in manually (or both).
+
+* Username/Password is missing

--- a/plugins/holland.backup.rsync/holland/__init__.py
+++ b/plugins/holland.backup.rsync/holland/__init__.py
@@ -1,0 +1,6 @@
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)

--- a/plugins/holland.backup.rsync/holland/backup/__init__.py
+++ b/plugins/holland.backup.rsync/holland/backup/__init__.py
@@ -1,0 +1,6 @@
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)

--- a/plugins/holland.backup.rsync/holland/backup/rsync.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync.py
@@ -21,6 +21,7 @@ flags = string(default='-avz')
 hardlinks = boolean(default=yes)
 one-file-system = boolean(default=no)
 exclude = list(default=None)
+bandwidth-limit = string(default=None)
 """.splitlines()
 
 class RsyncPlugin(object):
@@ -106,6 +107,9 @@ class RsyncPlugin(object):
 			source += self.config['rsync']['server'] + ":"
 		# Now concatenate all the above work with the desired path.
 		source += "/" + self.config['rsync']['directory']
+
+		if(self.config['rsync']['bandwidth-limit']):
+			cmd.append('--bwlimit=' + self.config['rsync']['bandwidth-limit'])
 
 		# Check on one-file-system flag
 		if(self.config['rsync']['one-file-system']):

--- a/plugins/holland.backup.rsync/holland/backup/rsync.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync.py
@@ -94,6 +94,7 @@ class RsyncPlugin(object):
 			if(self.config['rsync']['username']):
 				source += self.config['rsync']['username'] + "@"
 			source += self.config['rsync']['server']
+			# If a password was specified, toss it in as a env variable.
 			if(self.config['rsync']['password']):
 				env = {"RSYNC_PASSWORD": self.config['rsync']['password']}
 		# We're using SSH. If a username was specified, provide it.

--- a/plugins/holland.backup.rsync/holland/backup/rsync.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync.py
@@ -1,0 +1,84 @@
+import logging
+import os
+from subprocess import Popen, PIPE, STDOUT, list2cmdline
+from holland.core.exceptions import BackupError
+from holland.lib.compression import open_stream, lookup_compression
+from tempfile import TemporaryFile
+
+LOG = logging.getLogger(__name__)
+
+# Specification for this plugin
+# See: http://www.voidspace.org.uk/python/validate.html
+CONFIGSPEC = """
+[rsync]
+directory = string(default='/home')
+hardlinks = boolean(default=yes)
+""".splitlines()
+
+class RsyncPlugin(object):
+	def __init__(self, name, config, target_directory, dry_run=False):
+		"""Create a new RsyncPlugin instance
+
+		:param name: unique name of this backup
+		:param config: dictionary config for this plugin
+		:param target_directory: str path, under which backup data should be
+		                         stored
+		:param dry_run: boolean flag indicating whether this should be a real
+		                backup run or whether this backup should only go
+		                through the motions
+		"""
+		self.name = name
+		self.config = config
+		self.target_directory = target_directory
+		self.dry_run = dry_run
+		LOG.info("Validating config")
+		self.config.validate_config(CONFIGSPEC)
+
+	def estimate_backup_size(self):
+		total_size = 0
+		for dirpath, dirnames, filenames in os.walk(self.config['rsync']['directory']):
+			for f in filenames:
+				fp = os.path.join(dirpath, f)
+				# verify the symlink and such exist before trying to get its size
+				if os.path.exists(fp):
+					total_size += os.path.getsize(fp)
+		return total_size
+
+	def _open_stream(self, path, mode, method=None):
+        """Open a stream through the holland compression api, relative to
+        this instance's target directory
+        """
+        compression_method = method or self.config['compression']['method']
+        compression_level = self.config['compression']['level']
+        compression_options = self.config['compression']['options']
+        stream = open_stream(path,
+                             mode,
+                             compression_method,
+                             compression_level,
+                             extra_args=compression_options)
+        return stream
+
+	def backup(self):
+		if self.dry_run:
+			return
+		if not os.path.exists(self.config['rsync']['directory'])
+		 or not os.path.isdir(self.config['rsync']['directory']):
+			raise BackupError('{0} is not a directory!'.format(self.config['rsync']['directory']))
+		outdir = os.path.join(self.target_directory, self.config['rsync']['directory'])
+		cmd = ['rsync', 'avz', self.config['rsync']['directory'], outdir]
+		errlog = TemporaryFile()
+		stream = self._open_stream(outfile, 'w')
+		LOG.info("Executing: %s", list2cmdline(args))
+		pid = Popen(
+			cmd,
+			stdout=stream.fileno(),
+			stderr=errlog.fileno(),
+			close_fds=True)
+		status = pid.wait()
+		try:
+			errlog.flush()
+			errlog.seek(0)
+			for line in errlog:
+				LOG.error("%s[%d]: %s", list2cmdline(args), pid.pid, line.rstrip())
+		finally:
+			errlog.close()

--- a/plugins/holland.backup.rsync/holland/backup/rsync.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync.py
@@ -12,9 +12,9 @@ LOG = logging.getLogger(__name__)
 # See: http://www.voidspace.org.uk/python/validate.html
 CONFIGSPEC = """
 [rsync]
-method = string(default='local')
+method = option('local', 'ssh', 'rsync', default='local')
 server = string(default=None)
-directory = string(default='/home')
+directory = string(default='/')
 flags = string(default='-avz')
 hardlinks = boolean(default=yes)
 exclude = list(default=None)

--- a/plugins/holland.backup.rsync/holland/backup/rsync.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync.py
@@ -14,6 +14,7 @@ CONFIGSPEC = """
 [rsync]
 method = option('local', 'ssh', 'rsync', default='local')
 server = string(default=None)
+port = integer(default=None)
 username = string(default=None)
 password = string(default=None)
 directory = string(default='/')
@@ -94,20 +95,40 @@ class RsyncPlugin(object):
 			source = "rsync://"
 			if(self.config['rsync']['username']):
 				source += self.config['rsync']['username'] + "@"
+			# Add in the host
 			source += self.config['rsync']['server']
+			# If a port was specified, provide it as well.
+			if(self.config['rsync']['port']):
+				source += ":" + self.config['rsync']['port']
 			# If a password was specified, toss it in as a env variable.
 			if(self.config['rsync']['password']):
 				env = {"RSYNC_PASSWORD": self.config['rsync']['password']}
+
 		# We're using SSH. If a username was specified, provide it.
 		# Note no password will be provided here. SSH keys should be used.
 		# The "user@host:/path" syntax is being used here.
 		elif(self.config['rsync']['method'] == 'ssh'):
+			source = ""
 			if(self.config['rsync']['username']):
 				source = self.config['rsync']['username'] + "@"
 			source += self.config['rsync']['server'] + ":"
+
+			# Now we build the --rsh flag
+
+			#if(self.config['rsync']['port']):
+				#rsh = "--rsh='ssh"
+				#rsh += " -p"
+				#-p" #+ str(self.config['rsync']['port']) + "'"
+				#LOG.info(rsh)
+				#cmd.append(rsh)
+			#else:
+				#rsh="""--rsh='ssh'"""
+			#cmd.append(rsh)
+
 		# Now concatenate all the above work with the desired path.
 		source += "/" + self.config['rsync']['directory']
 
+		# Check on the bandwidth limit
 		if(self.config['rsync']['bandwidth-limit']):
 			cmd.append('--bwlimit=' + self.config['rsync']['bandwidth-limit'])
 

--- a/plugins/holland.backup.rsync/holland/backup/rsync.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync.py
@@ -59,13 +59,6 @@ class RsyncPlugin(object):
 		if not os.path.isdir(self.config['rsync']['directory']):
 			raise BackupError('{0} is not a directory!'.format(self.config['rsync']['directory']))
 
-		# Process exclusion tuples and turn them into
-		# --exclude flags
-		if self.config['rsync']['exclude']:
-			for exclude in self.config['rsync']['exclude']:
-				excludes.append("--exclude=" + exclude)
-
-
 		# Check if a previous backup directory exists
 		# if so, and hardlinks are enabled, use it for the --link-dest
 		self.spool = spool.Spool()

--- a/plugins/holland.backup.rsync/holland/backup/rsync.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync.py
@@ -2,7 +2,6 @@ import logging
 import os
 from subprocess import Popen, PIPE, STDOUT, list2cmdline
 from holland.core.exceptions import BackupError
-from holland.lib.compression import open_stream, lookup_compression
 from tempfile import TemporaryFile
 
 LOG = logging.getLogger(__name__)
@@ -44,34 +43,21 @@ class RsyncPlugin(object):
 					total_size += os.path.getsize(fp)
 		return total_size
 
-	def _open_stream(self, path, mode, method=None):
-        """Open a stream through the holland compression api, relative to
-        this instance's target directory
-        """
-        compression_method = method or self.config['compression']['method']
-        compression_level = self.config['compression']['level']
-        compression_options = self.config['compression']['options']
-        stream = open_stream(path,
-                             mode,
-                             compression_method,
-                             compression_level,
-                             extra_args=compression_options)
-        return stream
-
 	def backup(self):
 		if self.dry_run:
 			return
-		if not os.path.exists(self.config['rsync']['directory'])
-		 or not os.path.isdir(self.config['rsync']['directory']):
-			raise BackupError('{0} is not a directory!'.format(self.config['rsync']['directory']))
+
+		#if not os.path.exists(self.config['rsync']['directory'])
+		#or not os.path.isdir(self.config['rsync']['directory']):
+		#	raise BackupError('{0} is not a directory!'.format(self.config['rsync']['directory']))
 		outdir = os.path.join(self.target_directory, self.config['rsync']['directory'])
-		cmd = ['rsync', 'avz', self.config['rsync']['directory'], outdir]
+		cmd = ['rsync', '-avz', self.config['rsync']['directory'], outdir]
 		errlog = TemporaryFile()
-		stream = self._open_stream(outfile, 'w')
-		LOG.info("Executing: %s", list2cmdline(args))
+		#stream = self._open_stream(outfile, 'w')
+		LOG.info("Executing: %s", list2cmdline(cmd))
 		pid = Popen(
 			cmd,
-			stdout=stream.fileno(),
+			#stdout=stream.fileno(),
 			stderr=errlog.fileno(),
 			close_fds=True)
 		status = pid.wait()
@@ -79,6 +65,6 @@ class RsyncPlugin(object):
 			errlog.flush()
 			errlog.seek(0)
 			for line in errlog:
-				LOG.error("%s[%d]: %s", list2cmdline(args), pid.pid, line.rstrip())
+				LOG.error("%s[%d]: %s", list2cmdline(cmd), pid.pid, line.rstrip())
 		finally:
 			errlog.close()

--- a/plugins/holland.backup.rsync/holland/backup/rsync/__init__.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync/__init__.py
@@ -1,0 +1,1 @@
+from holland.backup.rsync.plugin import RsyncPlugin

--- a/plugins/holland.backup.rsync/holland/backup/rsync/plugin.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync/plugin.py
@@ -147,9 +147,11 @@ class RsyncPlugin(object):
 
 		# Do it!
 		errlog = TemporaryFile()
+		output = open(self.target_directory + "/output.txt", 'w')
 		LOG.info("Executing: %s", list2cmdline(cmd))
 		pid = Popen(
 			cmd,
+			stdout=output,
 			stderr=errlog.fileno(),
 			env=env,
 			close_fds=True)
@@ -160,4 +162,5 @@ class RsyncPlugin(object):
 			for line in errlog:
 				LOG.error("%s[%d]: %s", list2cmdline(cmd), pid.pid, line.rstrip())
 		finally:
+			output.close()
 			errlog.close()

--- a/plugins/holland.backup.rsync/holland/backup/rsync/plugin.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync/plugin.py
@@ -45,14 +45,15 @@ class RsyncPlugin(object):
 		self.config.validate_config(CONFIGSPEC)
 
 	def estimate_backup_size(self):
-		total_size = 0
-		for dirpath, dirnames, filenames in os.walk(self.config['rsync']['directory']):
-			for f in filenames:
-				fp = os.path.join(dirpath, f)
-				# verify the symlink and such exist before trying to get its size
-				if os.path.exists(fp):
-					total_size += os.path.getsize(fp)
-		return total_size
+		return 0
+		#total_size = 0
+		#for dirpath, dirnames, filenames in os.walk(self.config['rsync']['directory']):
+		#	for f in filenames:
+		#		fp = os.path.join(dirpath, f)
+		#		# verify the symlink and such exist before trying to get its size
+		#		if os.path.exists(fp):
+		#			total_size += os.path.getsize(fp)
+		#return total_size
 
 	def backup(self):
 		hardlink_cmd = ""

--- a/plugins/holland.backup.rsync/holland/backup/rsync/plugin.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync/plugin.py
@@ -21,8 +21,8 @@ directory = string(default='/')
 flags = string(default='-avz')
 hardlinks = boolean(default=yes)
 one-file-system = boolean(default=no)
-exclude = list(default=None)
 bandwidth-limit = string(default=None)
+exclude = list(default=None)
 """.splitlines()
 
 class RsyncPlugin(object):

--- a/plugins/holland.backup.rsync/holland/backup/rsync/plugin.py
+++ b/plugins/holland.backup.rsync/holland/backup/rsync/plugin.py
@@ -45,6 +45,10 @@ class RsyncPlugin(object):
 		self.config.validate_config(CONFIGSPEC)
 
 	def estimate_backup_size(self):
+		# This is 0 for now because estimating size for very large directories
+		# could be super time consuming and may not even be accurate if
+		# one-file-system is used. Another method other than what is below
+		# may need to be used instead.
 		return 0
 		#total_size = 0
 		#for dirpath, dirnames, filenames in os.walk(self.config['rsync']['directory']):

--- a/plugins/holland.backup.rsync/setup.cfg
+++ b/plugins/holland.backup.rsync/setup.cfg
@@ -1,6 +1,6 @@
-[egg_info]
-tag_build = dev
-tag_svn_revision = true
+#[egg_info]
+#tag_build = dev
+#tag_svn_revision = true
 
 [nosetests]
 with-coverage=1

--- a/plugins/holland.backup.rsync/setup.cfg
+++ b/plugins/holland.backup.rsync/setup.cfg
@@ -1,0 +1,7 @@
+[egg_info]
+tag_build = dev
+tag_svn_revision = true
+
+[nosetests]
+with-coverage=1
+cover-package=holland.backup.example

--- a/plugins/holland.backup.rsync/setup.py
+++ b/plugins/holland.backup.rsync/setup.py
@@ -1,0 +1,28 @@
+from setuptools import setup, find_packages
+
+version = '1.0.10'
+
+setup(name='holland.backup.rsync',
+      version=version,
+      description="rsync Plugin for Holland",
+      long_description="""\
+      rsync plugin for the Holland backup framework
+      """,
+      author='Tim Soderstrom',
+      author_email='holland-devel@googlegroups.com',
+      url='http://www.hollandbackup.org/',
+      license='GPLv2',
+      packages=find_packages(exclude=['ez_setup', 'examples', 'tests',
+                                      'tests.*']),
+      include_package_data=True,
+      zip_safe=False,
+      test_suite='tests',
+      install_requires=[
+          # -*- Extra requirements: -*-
+      ],
+      entry_points="""
+      [holland.backup]
+      rsync = holland.backup.rsync:RsyncPlugin
+      """,
+      namespace_packages=['holland', 'holland.backup'],
+    )

--- a/plugins/holland.backup.xtrabackup/setup.py
+++ b/plugins/holland.backup.xtrabackup/setup.py
@@ -4,7 +4,7 @@ version = '1.0.11'
 
 setup(name='holland.backup.xtrabackup',
       version=version,
-      description="Holland plugin for Percona XtraBackup"
+      description="Holland plugin for Percona XtraBackup",
       long_description="""\
       Holland plugin for Percona XtraBackup
       """,


### PR DESCRIPTION
I should have put these in two pulls but basically worked on 2 things:

rsync plugin:

For doing differential style backups using rsync, leveraging hard-links. I'm not trying to pressure this to go into mainline but wasn't sure otherwise how best to handle it as a 3rd party plugin outside of the tree. I've been using it for a while now for my own backups, though I'd consider this beta. Additionally, it could use some extra features (such as a way to set nice/ionice, although I wonder if that may be useful as a holland core config option).

Docs:

I didn't like how we were organizing provider configuration information under the main configuration section. Instead, I pulled out providers into their own section, where we can elaborate on what they do, and put references to them in the config section instead. I think it is much better.

Both of these are merely proposals. Probably worthy of more discussion in holland-discuss, but since I was going out of town for the weekend, I thought I'd go ahead and toss this out in case if was needed.
