### PR TITLE
Ensure data_length / index_length are integers

### DIFF
--- a/plugins/holland.lib.mysql/holland/lib/mysql/schema/base.py
+++ b/plugins/holland.lib.mysql/holland/lib/mysql/schema/base.py
@@ -225,8 +225,8 @@ class Table(object):
                        engine):
         self.database = database
         self.name = name
-        self.data_size = data_size
-        self.index_size = index_size
+        self.data_size = int(data_size)
+        self.index_size = int(index_size)
         self.engine = engine
         self.excluded = False
 


### PR DESCRIPTION
Fixes a bug where MariaDB 10.1 seems to be defaulting to decimal
when transforming certain integer types with coalesce/ifnull/etc.

Resolves #125