### PR TITLE
Add missing comma in xtrabackup plugin's setup.py

### DIFF
--- a/plugins/holland.backup.xtrabackup/setup.py
+++ b/plugins/holland.backup.xtrabackup/setup.py
@@ -4,7 +4,7 @@ version = '1.0.11'
 
 setup(name='holland.backup.xtrabackup',
       version=version,
-      description="Holland plugin for Percona XtraBackup"
+      description="Holland plugin for Percona XtraBackup",
       long_description="""\
       Holland plugin for Percona XtraBackup
       """,


### PR DESCRIPTION
Typo from a previous update that was causing a syntax error.