### PR TITLE
Bump master version to 1.0.12

### DIFF
--- a/contrib/holland.spec
+++ b/contrib/holland.spec
@@ -592,10 +592,10 @@ rm -rf %{buildroot}
 * Thu Jul 01 2010 Andrew Garner <andrew.garner@rackspace.com> - 1.0.0-3.rc3
 - Source updated to rc3
 
-* Tue Jun 28 2010 Andrew Garner <andrew.garner@rackspace.com> - 1.0.0-2.rc2
+* Mon Jun 28 2010 Andrew Garner <andrew.garner@rackspace.com> - 1.0.0-2.rc2
 - Source updated to rc2
 
-* Thu Jun 11 2010 Andrew Garner <andrew.garner@rackspace.com> - 1.0.0-1.rc1
+* Fri Jun 11 2010 Andrew Garner <andrew.garner@rackspace.com> - 1.0.0-1.rc1
 - Repackaging for release candidate
 - Using conditional builds to exclude experimental plugins
 
@@ -611,7 +611,7 @@ rm -rf %{buildroot}
 * Thu May 27 2010 BJ Dierkes <wdierkes@rackspace.com> - 0.9.9-9
 - Move plugins/README to README.plugins and install via %%doc
 
-* Mon May 25 2010 BJ Dierkes <wdierkes@rackspace.com> - 0.9.9-8
+* Tue May 25 2010 BJ Dierkes <wdierkes@rackspace.com> - 0.9.9-8
 - Adding holland.lib.lvm under -common subpackage
 
 * Wed May 19 2010 BJ Dierkes <wdierkes@rackspace.com> - 0.9.9-7
@@ -650,7 +650,7 @@ rm -rf %{buildroot}
 - No longer package plugins as eggs
 - Conditionally BuildRequire: python-nose and run nose tests if _with_tests
 
-* Thu Apr 07 2010 BJ Dierkes <wdierkes@rackspace.com> - 0.9.8-2.rs
+* Wed Apr 07 2010 BJ Dierkes <wdierkes@rackspace.com> - 0.9.8-2.rs
 - Rename holland-lvm to holland-mysqllvm, Obsoletes: holland-lvm
 - Manually install mysql-lvm.conf provider config (fixed in 0.9.9)
 - Install man files to _mandir
@@ -708,7 +708,7 @@ rm -rf %{buildroot}
 * Sat May 02 2009 BJ Dierkes <wdierkes@rackspace.com> - 0.3.1-1.2.rs
 - Build as noarch.
 
-* Tue Apr 29 2009 BJ Dierkes <wdierkes@rackspace.com> - 0.3.1-1.rs
+* Wed Apr 29 2009 BJ Dierkes <wdierkes@rackspace.com> - 0.3.1-1.rs
 - Latest sources.
 
 * Tue Apr 28 2009 BJ Dierkes <wdierkes@rackspace.com> - 0.3-1.rs

--- a/contrib/holland.spec
+++ b/contrib/holland.spec
@@ -3,7 +3,7 @@
 # el4 also... which doesn't support it
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
-%{!?holland_version: %global holland_version 1.0.11}
+%{!?holland_version: %global holland_version 1.0.12}
 
 # default %%rhel to make things easier to build
 %{!?rhel: %global rhel %%(%{__sed} 's/^[^0-9]*\\([0-9]\\+\\).*/\\1/' /etc/redhat-release)}
@@ -33,7 +33,7 @@
 
 Name:           holland
 Version:        %{holland_version}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pluggable Backup Framework
 Group:          Applications/Archiving
 License:        BSD
@@ -543,6 +543,9 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
+* Mon Feb 08 2016 Andrew Garner <andrew.garner@rackspace.com> - 1.0.12-2
+- Latest sources from upstream
+
 * Mon Jul 29 2013 Andrew Garner <andrew.garner@rackspace.com> - 1.0.10-1
 - Latest sources from upstream
 

--- a/plugins/holland.backup.example/setup.py
+++ b/plugins/holland.backup.example/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.backup.example',
       version=version,

--- a/plugins/holland.backup.mysql_lvm/setup.py
+++ b/plugins/holland.backup.mysql_lvm/setup.py
@@ -3,7 +3,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name="holland.backup.mysql_lvm",
       version=version,

--- a/plugins/holland.backup.mysqldump/setup.py
+++ b/plugins/holland.backup.mysqldump/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.backup.mysqldump',
       version=version,

--- a/plugins/holland.backup.mysqlhotcopy/setup.py
+++ b/plugins/holland.backup.mysqlhotcopy/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.backup.mysqlhotcopy',
       version=version,

--- a/plugins/holland.backup.pgdump/setup.py
+++ b/plugins/holland.backup.pgdump/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.backup.pgdump',
       version=version,

--- a/plugins/holland.backup.random/setup.py
+++ b/plugins/holland.backup.random/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.backup.random',
       version=version,

--- a/plugins/holland.backup.sqlite/setup.py
+++ b/plugins/holland.backup.sqlite/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.backup.sqlite',
       version=version,

--- a/plugins/holland.backup.tar/setup.py
+++ b/plugins/holland.backup.tar/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.10'
+version = '1.0.12'
 
 setup(name='holland.backup.tar',
       version=version,

--- a/plugins/holland.backup.xtrabackup/setup.py
+++ b/plugins/holland.backup.xtrabackup/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.backup.xtrabackup',
       version=version,

--- a/plugins/holland.lib.common/setup.py
+++ b/plugins/holland.lib.common/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.lib.common',
       version=version,

--- a/plugins/holland.lib.lvm/setup.py
+++ b/plugins/holland.lib.lvm/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.lib.lvm',
       version=version,

--- a/plugins/holland.lib.mysql/setup.py
+++ b/plugins/holland.lib.mysql/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name='holland.lib.mysql',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.0.11'
+version = '1.0.12'
 
 setup(name="holland",
       version=version,


### PR DESCRIPTION
This bumps the version numbers of all packages of core setup.py and plugins/*/setup.py 1.0.12 as well as the holland.spec.  Minor date discrepancies in holland.spec reported by rpmlint were fixed as well.