### PR TITLE
minor fixes for tar plugins

### DIFF
--- a/config/providers/tar.conf
+++ b/config/providers/tar.conf
@@ -1,0 +1,8 @@
+[tar]
+#directory = /home
+
+[compression]
+#method     = gzip
+#options    = 
+#inline     = yes
+#level      = 1

--- a/contrib/holland.spec
+++ b/contrib/holland.spec
@@ -402,8 +402,6 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%doc CHANGES.txt README README.plugins README.providers
-%doc INSTALL LICENSE config/backupsets/examples/
 %doc CHANGES.rst README README.plugins README.providers
 %doc INSTALL LICENSE config/backupsets/examples/
 %if %{with sphinxdocs}

--- a/contrib/holland.spec
+++ b/contrib/holland.spec
@@ -26,10 +26,10 @@
 %bcond_with     sphinxdocs
 %bcond_with     mysqlhotcopy
 %bcond_with     maatkit
+%bcond_with     tar
 %bcond_without  pgdump
 %bcond_without  sqlite
 %bcond_without  xtrabackup
-%bcond_without  tar
 
 Name:           holland
 Version:        %{holland_version}

--- a/contrib/holland.spec
+++ b/contrib/holland.spec
@@ -534,7 +534,7 @@ rm -rf %{buildroot}
 %files tar
 %defattr(-,root,root,-)
 %doc plugins/holland.backup.tar/{README,LICENSE}
-%{python_sitelib}/holland/backup/tar.py
+%{python_sitelib}/holland/backup/tar.py*
 %{python_sitelib}/holland.backup.tar-%{version}-*-nspkg.pth
 %{python_sitelib}/holland.backup.tar-%{version}-*.egg-info
 %config(noreplace) %{_sysconfdir}/holland/providers/tar.conf

--- a/contrib/holland.spec
+++ b/contrib/holland.spec
@@ -536,7 +536,7 @@ rm -rf %{buildroot}
 %files tar
 %defattr(-,root,root,-)
 %doc plugins/holland.backup.tar/{README,LICENSE}
-%{python_sitelib}/holland/backup/tar/
+%{python_sitelib}/holland/backup/tar.py
 %{python_sitelib}/holland.backup.tar-%{version}-*-nspkg.pth
 %{python_sitelib}/holland.backup.tar-%{version}-*.egg-info
 %config(noreplace) %{_sysconfdir}/holland/providers/tar.conf

--- a/plugins/holland.backup.tar/LICENSE
+++ b/plugins/holland.backup.tar/LICENSE
@@ -1,0 +1,15 @@
+Copyright (C) 2008-2016  Rackspace US, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/plugins/holland.backup.tar/README
+++ b/plugins/holland.backup.tar/README
@@ -1,0 +1,3 @@
+This packages provides a holland backup plugin to
+create a tar archive of the directory specified in
+the backup config.

--- a/plugins/holland.backup.tar/holland/backup/tar.py
+++ b/plugins/holland.backup.tar/holland/backup/tar.py
@@ -1,8 +1,8 @@
 import logging
 import os
-from subprocess import Popen, PIPE, STDOUT, list2cmdline
+from subprocess import Popen, list2cmdline
 from holland.core.exceptions import BackupError
-from holland.lib.compression import open_stream, lookup_compression
+from holland.lib.compression import open_stream
 from tempfile import TemporaryFile
 
 LOG = logging.getLogger(__name__)
@@ -20,35 +20,35 @@ level  = integer(min=0, max=9, default=1)
 """.splitlines()
 
 class TarPlugin(object):
-	def __init__(self, name, config, target_directory, dry_run=False):
-		"""Create a new TarPlugin instance
+    def __init__(self, name, config, target_directory, dry_run=False):
+        """Create a new TarPlugin instance
 
-		:param name: unique name of this backup
-		:param config: dictionary config for this plugin
-		:param target_directory: str path, under which backup data should be
-		                         stored
-		:param dry_run: boolean flag indicating whether this should be a real
-		                backup run or whether this backup should only go
-		                through the motions
-		"""
-		self.name = name
-		self.config = config
-		self.target_directory = target_directory
-		self.dry_run = dry_run
-		LOG.info("Validating config")
-		self.config.validate_config(CONFIGSPEC)
+        :param name: unique name of this backup
+        :param config: dictionary config for this plugin
+        :param target_directory: str path, under which backup data should be
+                                 stored
+        :param dry_run: boolean flag indicating whether this should be a real
+                        backup run or whether this backup should only go
+                        through the motions
+        """
+        self.name = name
+        self.config = config
+        self.target_directory = target_directory
+        self.dry_run = dry_run
+        LOG.info("Validating config")
+        self.config.validate_config(CONFIGSPEC)
 
-	def estimate_backup_size(self):
-		total_size = 0
-		for dirpath, dirnames, filenames in os.walk(self.config['tar']['directory']):
-			for f in filenames:
-				fp = os.path.join(dirpath, f)
-				# verify the symlink and such exist before trying to get its size
-				if os.path.exists(fp):
-					total_size += os.path.getsize(fp)
-		return total_size
+    def estimate_backup_size(self):
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(self.config['tar']['directory']):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                # verify the symlink and such exist before trying to get its size
+                if os.path.exists(fp):
+                    total_size += os.path.getsize(fp)
+        return total_size
 
-	def _open_stream(self, path, mode, method=None):
+    def _open_stream(self, path, mode, method=None):
         """Open a stream through the holland compression api, relative to
         this instance's target directory
         """
@@ -62,29 +62,32 @@ class TarPlugin(object):
                              extra_args=compression_options)
         return stream
 
-	def backup(self):
-		if self.dry_run:
-			return
-		if not os.path.exists(self.config['tar']['directory'])
-		 or not os.path.isdir(self.config['tar']['directory']):
-			raise BackupError('{0} is not a directory!'.format(self.config['tar']['directory']))
-		out_name = "{0}.tar".format(
-			self.config['tar']['directory'].lstrip('/').replace('/', '_'))
-		outfile = os.path.join(self.target_directory, out_name)
-		args = ['tar', 'c', self.config['tar']['directory']]
-		errlog = TemporaryFile()
-		stream = self._open_stream(outfile, 'w')
-		LOG.info("Executing: %s", list2cmdline(args))
-		pid = Popen(
-			args,
-			stdout=stream.fileno(),
-			stderr=errlog.fileno(),
-			close_fds=True)
-		status = pid.wait()
-		try:
-			errlog.flush()
-			errlog.seek(0)
-			for line in errlog:
-				LOG.error("%s[%d]: %s", list2cmdline(args), pid.pid, line.rstrip())
-		finally:
-			errlog.close()
+    def backup(self):
+        if self.dry_run:
+            return
+        if not os.path.exists(self.config['tar']['directory']) \
+         or not os.path.isdir(self.config['tar']['directory']):
+            raise BackupError('{0} is not a directory!'.format(self.config['tar']['directory']))
+        out_name = "{0}.tar".format(
+            self.config['tar']['directory'].lstrip('/').replace('/', '_'))
+        outfile = os.path.join(self.target_directory, out_name)
+        args = ['tar', 'c', self.config['tar']['directory']]
+        errlog = TemporaryFile()
+        stream = self._open_stream(outfile, 'w')
+        LOG.info("Executing: %s", list2cmdline(args))
+        pid = Popen(
+            args,
+            stdout=stream.fileno(),
+            stderr=errlog.fileno(),
+            close_fds=True)
+        status = pid.wait()
+        try:
+            errlog.flush()
+            errlog.seek(0)
+            for line in errlog:
+                LOG.error("%s[%d]: %s", list2cmdline(args), pid.pid, line.rstrip())
+        finally:
+            errlog.close()
+
+        if status != 0:
+            raise BackupError('tar failed (status={0})'.format(status))


### PR DESCRIPTION
- add missing providers/tar.conf - this is expected by holland.spec
- convert tabs to spaces
- cleanup unused imports
- fail if tar exits with non-zero status
- disable building tar plugin by default
  (due to requiring python2.6+)