### PR TITLE
fix bad iteration over rows in mysql50 metadata discovery

### DIFF
--- a/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
+++ b/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
@@ -138,7 +138,7 @@ class MySQLClient(object):
                     LOG.warning("Invalid table %s.%s: %s",
                                 row['database'], row['name'],
                                 row['comment'] or '')
-            for key in row:
+            for key in row.keys():
                 valid_keys = [
                     'database',
                     'name',


### PR DESCRIPTION
This was previously changed as part of a fix for invalid
view detection in MySQL 5.0, where views were never being
detected correctly in order for the invalid view filtering
to work.  Unfortunately this introduced mutating the row
dictionary while iterating over the raw dictionary directly
which results in a "dictionary changed size during iteration"
error.  keys() are not iterated over to avoid that situation.