### PR TITLE
Fix holland-xtrabackup percona-xtrabackup dependency

### DIFF
--- a/contrib/holland.spec
+++ b/contrib/holland.spec
@@ -158,7 +158,7 @@ License: GPLv2
 Group: Development/Libraries
 Requires: %{name} = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
-Requires: xtrabackup >= 1.2
+Requires: percona-xtrabackup
 
 %description xtrabackup
 This package provides a Holland plugin for Percona Xtrabackup. This


### PR DESCRIPTION
contrib/holland.spec had an ancient dependency on
"xtrabackup >= 1.2", but for any remotely recent xtrabackup
this should be "percona-xtrabackup".