### PR TITLE
Revert broken SHOW SLAVE STATUS fix for LP#1220841

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,18 @@ http://bugs.launchpad.net/holland-backup
 GH# referes to the deprecated github bug tracker here:
 https://github.com/holland-backup/holland/issues
 
+1.0.14 - unreleased
+-------------------
+
+holland
++++++++
+
+- A fix for launchpad bug #1220841 caused plugins that used
+  "SHOW SLAVE STATUS" via the holland mysql lib to fail with
+  an "unknown encoding: binary" error.  The changes for 
+  LP #1220841 have been reverted.
+
+
 1.0.12 - Feb 8, 2016
 --------------------
 

--- a/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
+++ b/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
@@ -322,10 +322,8 @@ class MySQLClient(object):
         :returns: slave status dict
         """
         sql = "SHOW SLAVE STATUS"
-        charset = self.character_set_name()
         cursor = self.cursor()
         try:
-            self.set_character_set('binary')
             cursor.execute(sql)
             keys = [col[0].lower() for col in cursor.description]
             slave_status = cursor.fetchone()
@@ -334,14 +332,8 @@ class MySQLClient(object):
             if not slave_status:
                 return None
             else:
-                result = []
-                for value in slave_status:
-                    if isinstance(value, basestring):
-                        value = value.decode(charset, 'ignore')
-                    result.append(value)
-                return dict(zip(keys, result))
+                return dict(zip(keys, slave_status))
         finally:
-            self.set_character_set(charset)
             cursor.close()
 
     def show_master_status(self):


### PR DESCRIPTION
The fix for LP#1220841 breaks show_slave_status() in the holland mysql client ``show_slave_status()`` method.  ``binary`` is not a valid character set for MySQLdb. This leads to an 'unknown encoding' error and the backup fails.

Without changing connectors to something other than MySQLdb - where 'raw' binary strings can be had easily - I think [LP#1220841](https://bugs.launchpad.net/holland-backup/+bug/1220841)  is not easily fixed. The original fix for this show slave status bug is reverted here to address the serious defect it introduced in holland 1.0.12.