### PR TITLE
Fix lock-method = auto-detect for MySQL 5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,13 @@ holland
   an "unknown encoding: binary" error.  The changes for 
   LP #1220841 have been reverted.
 
+holland-mysqldump
++++++++++++++++++
+
+- A bug was introduced in 1.0.12 which caused mysqldump's lock-method
+  "auto-detect" option to always use lock-tables under MySQL 5.0
+  environments. (Fixes GH#148)
+
 
 1.0.12 - Feb 8, 2016
 --------------------

--- a/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
+++ b/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
@@ -138,6 +138,8 @@ class MySQLClient(object):
                     LOG.warning("Invalid table %s.%s: %s",
                                 row['database'], row['name'],
                                 row['comment'] or '')
+            else:
+                row['engine'] = row['engine'].lower()
             for key in row.keys():
                 valid_keys = [
                     'database',


### PR DESCRIPTION
There was a regression from the fix for LP#1081261 which caused
storage engine name comparison to be done in lowercase. The engine
attribute was canonicalized in the path for INFORMATION_SCHEMA
(MySQL 5.1+), but not for the "SHOW TABLE STATUS" path (used for
MySQL 5.0 and earlier). This causes the mysqldump option
lock-method=auto-detect to always default to 'non-transactional'
for MySQL 5.0 envionments and use the default mysqldump option
--lock-tables.

Resolves #148