### PR TITLE
Reorder !include in generated my.cnf

### DIFF
--- a/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
+++ b/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
@@ -61,8 +61,8 @@ class XtrabackupPlugin(object):
 
         defaults_path = join(self.target_directory, 'my.cnf')
         client_opts = self.config['mysql:client']
-        includes = [self.config['xtrabackup']['global-defaults']] + \
-                   client_opts['defaults-extra-file']
+        includes = client_opts['defaults-extra-file'] + \
+                   [self.config['xtrabackup']['global-defaults']]
         util.generate_defaults_file(defaults_path, includes, client_opts)
         self.defaults_path = defaults_path
 


### PR DESCRIPTION
Workaround for versions of Percona XtraBackup before 2.2.6:

https://bugs.launchpad.net/percona-xtrabackup/+bug/1343722

Currently, specification of socket in .my.cnf via defaults-extra-file can result in a silent failure (wrong data) for old versions of Percona XtraBackup

The proposed change includes [mysql:client] defaults-extra-file first, so that values in [xtrabackup] global-defaults win