### PR TITLE
Added code to allowed invalid views codes if exclusion is set to yes.

### DIFF
--- a/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
+++ b/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
@@ -434,7 +434,7 @@ def exclude_invalid_views(schema, client, definitions_file):
                             raise MySQLError(error_code, msg)
                 except MySQLError, exc:
                     # 1356 = View references invalid table(s)...
-                    if exc.args[0] in (1356, 1142, 1143, 1449, 1267):
+                    if exc.args[0] in (1356, 1142, 1143, 1449, 1267, 1271):
                         invalid_view = True
                     else:
                         LOG.error("Unexpected error when checking invalid "


### PR DESCRIPTION
Error occurs in case there's a Illegal mix of collations.
----------------------------
perror 1271
MySQL error code 1271 (ER_CANT_AGGREGATE_NCOLLATIONS): Illegal mix of collations for operation '%s'
----------------------------