### PR TITLE
Revert "Reorder !include in generated my.cnf"

### DIFF
--- a/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
+++ b/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
@@ -61,8 +61,8 @@ class XtrabackupPlugin(object):
 
         defaults_path = join(self.target_directory, 'my.cnf')
         client_opts = self.config['mysql:client']
-        includes = client_opts['defaults-extra-file'] + \
-                   [self.config['xtrabackup']['global-defaults']]
+        includes = [self.config['xtrabackup']['global-defaults']] + \
+                   client_opts['defaults-extra-file']
         util.generate_defaults_file(defaults_path, includes, client_opts)
         self.defaults_path = defaults_path
 


### PR DESCRIPTION
Reverts holland-backup/holland#151

Reading the server my.cnf after client .cnf options means `[mysqld]`'s user option is prioritized over whatever `[client]`/`[xtrabackup]` user option(s) might be specified in `~/.my.cnf` or elsewhere in the server my.cnf.  When innobackup connects it will often use the server's "user" option (almost always 'mysql') which leads to an auth failure / backup failure.  Percona XtraBackup using mysqld --user as a client option is an open bug.

Reverting this for now as I think the current plugin behavior with this change is not right and not so much of an issue for modern versions of Percona XtraBackup.