### PR TITLE
Documentation Updates (w/o rsync plugin)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Holland'
-copyright = u'2011-2015, Holland Core Team'
+copyright = u'2011-2017, Holland Core Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig',
         # 'sphinx.ext.viewcode'
         ]
 
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Holland'
-copyright = u'2011-2013, Holland Core Team'
+copyright = u'2011-2015, Holland Core Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -135,8 +135,7 @@ backup set configuration file.
 
     [holland:backup]
     plugin = <plugin>
-    backups-to-keep = #
-    estimated-size-factor = #
+    ...
 
 .. _holland-backup-config_options:
 
@@ -172,15 +171,6 @@ helper plugins (which are defined within their own sections - see below).
     whatever process is calling holland will retry when a backup fails.
     This behavior can be disabled by setting auto-purge-failures = no when
     partial backups might be useful or when troubleshooting a backup failure.
-
-.. describe:: purge-on-demand = [yes|no]
-
-   If enabled, this option will cause holland to attempt to purge old backups
-   within the same backupset to free enough space to allow a new backup to
-   start rather than failing when it appears that there is insufficient space
-   to run a new backup.  If the space consumed by all purgable backups is less
-   than the estimated space for a new backup, no backups are purged as the
-   new backup will fail regardless.
 
 .. describe:: purge-policy = [manual|before-backup|after-backup]
 
@@ -256,8 +246,6 @@ For Example
     after-backup-command = echo ${backupset} completed successfully.  Files are in ${backupdir}
     failed-backup-command = echo "${backupset} failed!" | mail -s "${backupset} backup failed" sysadmins@example.com
 
-
-
 Provider Plugin Configs
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -270,30 +258,14 @@ For advanced users, the defaults for each provider plugin can be changed
 by editing the default configuration file for said provider. These files are
 located in ``/etc/holland/providers`` by default.
 
-MySQL Plugins
-"""""""""""""
-.. toctree::
-    :maxdepth: 1
-
-    mysqldump <provider_plugins/mysqldump>
-    MySQL + LVM <provider_plugins/mysql-lvm>
-    mysqldump + LVM <provider_plugins/mysqldump-lvm>
-    Plugin for Percona XtraBackup <provider_plugins/xtrabackup>
-    MySQL Client Helper Plugin <provider_plugins/mysqlconfig>
-
-Other Plugins
-"""""""""""""
-.. toctree::
-    :maxdepth: 1
-
-    pgdump (PostgreSQL) <provider_plugins/pgdump>
-    Example Plugin <provider_plugins/example>
+For more information on configuring a specific provider, see :doc:`providers`
 
 Helper Plugins
 """"""""""""""
 .. toctree::
     :maxdepth: 1
 
+    MySQL Client Helper Plugin <provider_plugins/mysqlconfig>
     Compression Helper Plugin <provider_plugins/compression>
 
 Backup Set Config Example

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Table of Contents
     intro
     commands
     overview
+    providers
     config
 
 Indices and tables
@@ -18,4 +19,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,12 +1,30 @@
 Introduction to Holland
 =======================
 
-Holland is an Open Source backup framework originally developed by Rackspace 
+Holland is an Open Source backup framework originally developed by Rackspace
 and written in Python. The original intent was to offer more reliability and
 flexilibity when backing up MySQL databases, though the current version is
-now able to backup MySQL and PostgreSQL databases. Because Holland is 
+now able to backup MySQL and PostgreSQL databases. Because Holland is
 plugin-based framework, it can conceivably backup most anything you want
 by whatever means you want.
+
+General Concepts
+----------------
+Holland is built around the concept of providers and backup-sets.
+
+A provider implements a backup solution. This can range from backing up MySQL
+databases using mysqldump, LVM, or Xtrabackup; or PostgreSQL. holland is a
+pluggable framework, so other backup providers can be created beyond these
+as well.
+
+A backup-set defines a backup and includes global parameters, such as which
+provider will be used and how many backups to keep; as well as
+provider-specific configuration options, such as databases to exclude, user
+credentials, servers, etc. While some providers share similar options with
+each other, for the most part each provider has its own set of configuration
+options.
+
+For more information, see :doc:`overview`
 
 Dependencies
 ------------
@@ -23,7 +41,7 @@ MySQL based plugins additional require the MySQLdb python connector:
 
 For Red-Hat Enterprise Linux 5, all dependencies are available directly from
 the base channels. For Red-Hat Enterprise Linux 4, EPEL is required for
-python-setuptools. 
+python-setuptools.
 
 Note that other plugins may have additional dependency requirements.
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1,65 +1,53 @@
 Usage and Implementation Overview
 =================================
 
-Because Holland is very pluggable, it may first seem a bit confusing when
-it comes to configuring Holland to do something useful. Out of the box,
-Holland is designed to backup MySQL databases using the mysqldump provider.
-This is the simplest setup, and may be sufficient for most people. However, 
-others may wish to have more fine-grained control over their backups and/or 
-use another method other than mysqldump.
+Holland is built around the concept of plugins, though for the end user, most
+of these plugins will be in the form of backup providers and their helper
+plugins. These are configured by way of a backup-set which defines the
+characteristics of a particular backup.
 
-For instance, one can configure a backup set to backup certain databases
-using mysqldump, others using the mysql-lvm plugins etc. All this is done
-by a mix of plugins (sometimes called providers) and backup-sets.
-
-Backup-Sets
-^^^^^^^^^^^
-
-Each backup-set implements a backup plugin (provider) and often some helper
-plugins for things such as compression. Plugins come with a set of defaults
-such that only values that need to be overridden need to be specified, 
-although it is perfectly acceptable to specify options that are already 
-default - one would merely be stating the obvious. Doing so would also 
-make sure future changes to the defaults in Holland do not impact existing
-backup-sets.
+.. _overview-providers:
 
 Provider Plugins
 ^^^^^^^^^^^^^^^^
 
 Provider plugins provide a backup service for use in a backup set. They
 are the interface between Holland and the method of backing up data.
-As of Holland 1.0.8, there are 5 providers included with Holland:
 
-* mysqldump
-
-    Uses the ``mysqldump`` utility to backup MySQL databases.
-
-* MySQL + LVM
-
-    Backup MySQL databases using LVM snapshots which allows for near lockless 
-    or fully lockless (when transactional engines are used) backups. MySQL
-    must be running on an LVM volume with sufficient free extents to store
-    a working snapshot. It is also extremely ill-advised to store the backup
-    on the same volume as MySQL.
-
-* Support for `Percona XtraBackup <http://www.percona.com/software/percona-xtrabackup>`_
-
-    .. versionadded:: 1.0.8
-    
-    Backup MySQL databases using `Percona XtraBackup <http://www.percona.com/software/percona-xtrabackup>`_.
-    This provides a near lockless backup when using the InnoDB storage engine
-    while also providing a mysqlhotcopy style backup for MyISAM tables.
-
-* pgdump
-
-    Backup PostgreSQL databases using the ``pgdump`` utility.
-
-* Example
-
-    This is used solely as a template for designing providers. It otherwise
-    does nothing.
-    
 As Holland is a framework, it can actually backup most anything as long
-as there is a provider plugin for it. This includes things that have
-nothing to do with databases. The idea is to present an easy to use 
+as there is a provider plugin for it. The idea is to present an easy to use
 and clear method of backing up and restoring backups no matter the source.
+
+Backup-Sets
+^^^^^^^^^^^
+A backup-set is compromised of global, provider, and helper plugin
+configuration options which make up a particular backup. These options are
+stored in a simple INI-based configuration file. The name of the configuration
+file corresponds to the name of the backup set.
+
+For instance, once might want to backup a handful of MySQL databases using
+some specific mysqldump settings; while backing up another set of MySQL
+databases using different settings. To do this, one might create two backups
+sets for each scenario.
+
+Most plugins come with a set of defaults such that only values that need to be
+overridden need to be specified in a backup-set if desired. Such defaults
+can be modified on a global basis by editing the global provider configuration
+files (see :ref:`overview-providers`).
+
+Backups
+^^^^^^^
+Backups are of course the end product of the whole exercise. Holland stores
+these under the ``backup_direcotry`` defined in the main ``holland.conf``
+configuration file. The default location is usually ``/var/spool/holland``.
+Under this directory there is a sub-directory for individual backup-sets.
+Under those directories are the actual backup directories. The name of each
+backup directory is the timestamp of when it was run. As of Holland 1.0.8
+or newer, there are also ``newest`` and ``oldest`` directories which,
+perhaps unsurprisingly, correspond to the newest and oldest backup.
+
+As implied, there can be multiple backups under a backup-set. The scheduling
+of running backups is up to you. Holland does not care how often backups are
+run - it only cares about how many backups to keep. This, with the help of
+services like ``cron``, one can be fairly flexible about the scheduling and
+frequency of backups.

--- a/docs/source/provider_plugins/compression.rst
+++ b/docs/source/provider_plugins/compression.rst
@@ -1,5 +1,5 @@
 [compression]
--------------
+_____________
 
 Specify various compression settings, such as compression utility,
 compression level, etc.

--- a/docs/source/provider_plugins/databasefiltering.rst
+++ b/docs/source/provider_plugins/databasefiltering.rst
@@ -1,5 +1,5 @@
 Database and Table filtering
-----------------------------
+""""""""""""""""""""""""""""
 
 **databases** = <glob>
 
@@ -9,12 +9,12 @@ Database and Table filtering
 
 **exclude-tables** = <glob>
 
-The above options accepts GLOBs in comma-separated lists. Multiple 
-filtering options can be specified. When filtering on tables, be sure to 
-include both the database and table name. 
+The above options accepts GLOBs in comma-separated lists. Multiple
+filtering options can be specified. When filtering on tables, be sure to
+include both the database and table name.
 
-Be careful with quotes. Normally these are not needed, but  when quotes 
-are necessary, be sure to only quote each filtering statement, as 
+Be careful with quotes. Normally these are not needed, but  when quotes
+are necessary, be sure to only quote each filtering statement, as
 opposed to putting quotes around all statements.
 
 Below are a few examples of how these can be applied:
@@ -26,7 +26,7 @@ Default (backup everything)::
 
 Using database inclusion and exclusions::
 
- databases = drupal*, smf_forum, 
+ databases = drupal*, smf_forum,
  exclude-databases = drupal5
 
 Including Tables::
@@ -36,4 +36,3 @@ Including Tables::
 Excluding Tables::
 
   exclude-tables = mydb.uselesstable1, x_cart.*, *.sessions
-

--- a/docs/source/provider_plugins/example.rst
+++ b/docs/source/provider_plugins/example.rst
@@ -1,8 +1,8 @@
 .. _config-example:
 
-Example Provider Configuration [example]
-========================================
+Example
+=======
 
 There are currently no configuration options for the example provider.
-It is provided as a skeleton for anyone wishing to write their own 
+It is provided as a skeleton for anyone wishing to write their own
 provider plugin.

--- a/docs/source/provider_plugins/mysql-lvm.rst
+++ b/docs/source/provider_plugins/mysql-lvm.rst
@@ -1,37 +1,40 @@
 .. _config-mysql-lvm:
 
-MySQL LVM Provider Configuration [mysql-lvm]
-============================================
+MySQL LVM
+=========
 
-Creates an LVM snapshot of a running MySQL instance and performs a 
+Creates an LVM snapshot of a running MySQL instance and performs a
 binary-based backup with minimal locking. MySQL must be running on an
 LVM volume with reserved space for snapshots. It is highly recommended
 that this volume be separate from the one storing the resulting backups.
 
+Configuration
+-------------
+
 [mysql-lvm]
------------
+___________
 
 **snapshot-size** = <size-in-MB>
 
-    The size of the snapshot itself. By default it is 20% of the size of  the 
-    MySQL LVM mount or the remaining free-space in the Volume Group (if there 
-    is less than 20% available) up to 15GB. If snapshot-size is defined, the 
+    The size of the snapshot itself. By default it is 20% of the size of  the
+    MySQL LVM mount or the remaining free-space in the Volume Group (if there
+    is less than 20% available) up to 15GB. If snapshot-size is defined, the
     number represents the size of the snapshot in megabytes.
 
 **snapshot-name** = <name>
 
-    The name of the snapshot, the default being the name of the MySQL LVM 
+    The name of the snapshot, the default being the name of the MySQL LVM
     volume + "_snapshot" (ie Storage-MySQL_snapshot)
-    
-**snapshot-mountpoint** = <path>    
-    
-    Where to mount the snapshot. By default a randomly generated directory 
+
+**snapshot-mountpoint** = <path>
+
+    Where to mount the snapshot. By default a randomly generated directory
     under /tmp is used.
 
 **innodb-recovery** = yes | no (default: no)
 
-    Whether or not to run an InnoDB recovery operation. This avoids needing 
-    to do so during a restore, though will make the backup process itself 
+    Whether or not to run an InnoDB recovery operation. This avoids needing
+    to do so during a restore, though will make the backup process itself
     take longer.
 
 **force-innodb-backup** = yes | no (default: no)
@@ -41,26 +44,26 @@ that this volume be separate from the one storing the resulting backups.
     on entirely separate logical volumes.
 
 **lock-tables** = yes | no (default: yes)
-    
+
     Whether or not to run a FLUSH TABLES WITH READ LOCK to grab various
     bits of information (such as the binary log name and position). Disabling
     this requires that binary logging is disabled and InnoDB is being used
     exclusively. Otherwise, it is possible that the backup could contain
     crashed tables.
-    
+
 **extra-flush-tables** = yes | no (default: yes)
-    
-    Whether or not to run a FLUSH TABLES before running the full 
+
+    Whether or not to run a FLUSH TABLES before running the full
     FLUSH TABLES WITH READ LOCK. Should make the FLUSH TABLES WITH READ LOCK
     operation a bit faster.
 
 
 [tar]
------
+_____
 
 **exclude** = pattern[, pattern...]
 
-Patterns to exclude from archive.   These should be relative paths and are almost 
+Patterns to exclude from archive.   These should be relative paths and are almost
 always relative to the mysql data directory.  For instance to exclude binary logs
 in the data directory from the backup you might specify:
 exclude = ./bin-log.*, mysql.sock
@@ -69,7 +72,7 @@ exclude = ./bin-log.*, mysql.sock
 
 Additional arguments to append to the tar commandline before the backup path is specified.
 This should be the full string as you might specify on the commandline. Shell globbing is not
-supported.  
+supported.
 
 For instance you
 might add the /etc/my.cnf to the tar archive via:

--- a/docs/source/provider_plugins/mysqlconfig.rst
+++ b/docs/source/provider_plugins/mysqlconfig.rst
@@ -1,5 +1,5 @@
 MySQL connection info [mysql:client]
-------------------------------------
+____________________________________
 
 These are optional and, if left undefined, Holland will try to login using
 the standard .my.cnf conventions.

--- a/docs/source/provider_plugins/mysqldump-lvm.rst
+++ b/docs/source/provider_plugins/mysqldump-lvm.rst
@@ -1,14 +1,17 @@
 .. _config-mysqldump-lvm:
 
-mysqldump LVM Provider Configuration [mysqldump-lvm]
-====================================================
+mysqldump + LVM
+===============
 
 Backs up one or more MySQL databases by creating an LVM snapshot and
 then starting a instance of MySQL on top of it to then perform a
 mysqldump. This effectively produces a non-blocking logical backup.
 
+Configuration
+-------------
+
 [mysql-lvm]
------------
+___________
 
 **snapshot-size** = <size-in-MB>
 
@@ -48,7 +51,7 @@ mysqldump. This effectively produces a non-blocking logical backup.
     operation a bit faster.
 
 [mysqld]
---------
+________
 
 **mysqld-exe** = <path>[, <path>...] (default: mysqld in PATH, /usr/libexec/mysqld)
 
@@ -68,7 +71,7 @@ mysqldump. This effectively produces a non-blocking logical backup.
     Path to the --tmpdir that mysqld should use.
 
 [mysqldump]
------------
+___________
 
 mysqldump-lvm supports almost all of the options from the mysqldump plugin.
 --master-data is not supported, as the mysqld process will not read binary

--- a/docs/source/provider_plugins/mysqldump.rst
+++ b/docs/source/provider_plugins/mysqldump.rst
@@ -1,12 +1,23 @@
 .. _config-mysqldump:
 
-mysqldump Provider Configuration [mysqldump]
-============================================
+mysqldump
+=========
 
-Backs up one or more MySQL databases using the mysqldump tool.
+Uses the ``mysqldump`` utility to backup one or more MySQL databases using a
+logical backup (aka a flat SQL file). Many options are available for which
+databases should be backed up and how.
+
+``mysqldump`` style backups tend to result in smaller
+backups, at least when dealing with databases which have few, if any,
+binary objects (BLOBs). That said, ``mysqldump`` tends to be slow and require
+more system resources than the other options. Restores likewise can take a
+very long time for large databases.
+
+Configuration
+-------------
 
 [mysqldump]
------------
+___________
 
 **mysql-binpath** = /path/to/mysql/bin
 
@@ -142,7 +153,7 @@ Backs up one or more MySQL databases using the mysqldump tool.
     be difficult if multiple databases are defined in the backup set.
 
     When backing up all databases within a single file, the backup file
-    will be named ``all_databases.sql``. If compression is used, the 
+    will be named ``all_databases.sql``. If compression is used, the
     compression extension will be appended to the filename
     (e.g. ``all_databases.sql.gz``).
 
@@ -172,12 +183,7 @@ Backs up one or more MySQL databases using the mysqldump tool.
     information schema is used, which may be slow particularly for a large
     number of tables.
 
-Database and Table filtering
-----------------------------
-.. toctree::
-    :maxdepth: 1
-
-    databasefiltering
+.. include:: databasefiltering.rst
 
 .. include:: compression.rst
 

--- a/docs/source/provider_plugins/pgdump.rst
+++ b/docs/source/provider_plugins/pgdump.rst
@@ -1,12 +1,15 @@
 .. _config-pgdump:
 
-pgdump Provider Configuration [pgdump]
-======================================
+pgdump
+======
 
 Backs up a PostgreSQL instance using the pgdump utility.
 
+Configuration
+-------------
+
 [pgdump]
---------
+________
 
 **format** = custom | tar | plain (default: custom)
 
@@ -21,7 +24,7 @@ Backs up a PostgreSQL instance using the pgdump utility.
 .. include:: compression.rst
 
 [pgauth]
---------
+________
 
 **username** = <name>
 

--- a/docs/source/provider_plugins/xtrabackup.rst
+++ b/docs/source/provider_plugins/xtrabackup.rst
@@ -1,7 +1,7 @@
 .. _config-xtrabackup:
 
-Holland Plugin for Percona XtraBackup Configuration [xtrabackup]
-=========================================================================
+Xtrabackup
+==========
 
 Backup a MySQL instance using `Percona XtraBackup`_.
 
@@ -10,8 +10,11 @@ Backup a MySQL instance using `Percona XtraBackup`_.
    trademark to imply a relationship with, or endorsement or sponsorship
    of the Holland Project by Percona.
 
+Configuration
+-------------
+
 [xtrabackup]
-------------
+____________
 
 **global-defaults** = <path> (default: /etc/my.cnf)
 
@@ -23,23 +26,23 @@ Backup a MySQL instance using `Percona XtraBackup`_.
     The path to the innobackupex script to run. If this is a relative path
     this will be found in holland's environment PATH as configured in
     /etc/holland/holland.conf.
-    
-    
-**ibbackup** = <name>    
-    
+
+
+**ibbackup** = <name>
+
     The path to the ibbackup command to use.  By default, no --ibbackup option
     is pass to the innobackupex script.  Usually innobackupex will detect this
     by itself and this should not need to be set.
 
 **stream** = tar|xbstream|yes|no (default: tar)
 
-    Whether to generate a streaming backup. 
+    Whether to generate a streaming backup.
 
 .. versionchanged:: 1.0.8
    'tar' and 'xbstream' are now valid options.  The old stream = yes is
    now equivalent to stream = tar and stream = no disables streaming
    entirely and will result in a normal directory copy with xtrabackup
-       
+
 
 **apply-logs** = yes | no (default: yes)
 
@@ -52,11 +55,11 @@ Backup a MySQL instance using `Percona XtraBackup`_.
     .. versionadded:: 1.0.8
 
 **slave-info** = yes | no (default: yes)
-    
+
     Whether to enable the --slave-info innobackupex option
 
 **safe-slave-backup** = yes | no (default: yes)
-    
+
     Whether to enable the --safe-slave-backup innobackupex option.
 
 **no-lock** = yes | no (default: no)

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -1,0 +1,30 @@
+Backup Providers
+================
+
+Here is an overview the providers included with Holland. For specific
+configuration details on how to use these with a backup-set, see :doc:`config`
+
+MySQL Providers
+^^^^^^^^^^^^^^^
+
+These providers are for backing up MySQL databases using various means. Since
+there are so many providers specific to MySQL, these are given their own
+section.
+
+.. toctree::
+    :maxdepth: 1
+
+    provider_plugins/mysqldump
+    provider_plugins/mysql-lvm
+    provider_plugins/mysqldump-lvm
+    provider_plugins/xtrabackup
+
+Other Providers
+^^^^^^^^^^^^^^^
+These are providers which do something other than backup a MySQL database.
+
+.. toctree::
+    :maxdepth: 1
+
+    provider_plugins/pgdump
+    provider_plugins/example


### PR DESCRIPTION
Here's the original documentation updates I made, without the rsync plugin. Admittedly I haven't gone through them in depth other than making sure they built and had some of the changes I knew I made. Should be the same as the original PR (again minus the rsync stuff which I'll deal with later, per the list discussion).