### PR TITLE
Log timestamp of issuing "STOP SLAVE"

### DIFF
--- a/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
+++ b/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
@@ -365,6 +365,7 @@ class MySQLClient(object):
         sql = "STOP SLAVE"
         if sql_thread_only:
             sql += " SQL_THREAD"
+        LOG.info("Issuing %s", sql)
         cursor = self.cursor()
         result = cursor.execute(sql)
         cursor.close()


### PR DESCRIPTION
Currently, it is not obvious that a delay can be caused by "STOP SLAVE" waiting on a query or rollback.


Before proposed change:

2017-02-13 21:30:37,541 [INFO] Holland 1.0.14 started with pid 24174
2017-02-13 21:30:37,552 [INFO] --- Starting backup run ---
2017-02-13 21:30:37,556 [INFO] Creating backup path /var/spool/holland/mysqldump_stop_slave/20170213_213037
2017-02-13 21:30:37,583 [INFO] Estimating size of mysqldump backup
2017-02-13 21:30:37,596 [INFO] Estimated Backup Size: 800.49KB
2017-02-13 21:30:37,596 [INFO] Starting backup[mysqldump_stop_slave/20170213_213037] via plugin mysqldump
2017-02-13 21:30:59,701 [INFO] Stopped slave
2017-02-13 21:30:59,702 [INFO] MySQL Replication has been stopped.
2017-02-13 21:30:59,703 [INFO] Using mysqldump executable: /usr/bin/mysqldump
2017-02-13 21:30:59,709 [INFO] mysqldump version 5.6.34



With PR:

2017-02-13 21:31:26,849 [INFO] Holland 1.0.14 started with pid 24232
2017-02-13 21:31:26,861 [INFO] --- Starting backup run ---
2017-02-13 21:31:26,866 [INFO] Creating backup path /var/spool/holland/mysqldump_stop_slave/20170213_213126
2017-02-13 21:31:26,894 [INFO] Estimating size of mysqldump backup
2017-02-13 21:31:26,908 [INFO] Estimated Backup Size: 800.52KB
2017-02-13 21:31:26,908 [INFO] Starting backup[mysqldump_stop_slave/20170213_213126] via plugin mysqldump
2017-02-13 21:31:26,910 [INFO] Issuing STOP SLAVE SQL_THREAD
2017-02-13 21:31:51,017 [INFO] Stopped slave
2017-02-13 21:31:51,018 [INFO] MySQL Replication has been stopped.
2017-02-13 21:31:51,019 [INFO] Using mysqldump executable: /usr/bin/mysqldump
2017-02-13 21:31:51,025 [INFO] mysqldump version 5.6.34