### PR TITLE
Clean up logging for slave status sanity  check

### DIFF
--- a/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
+++ b/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
@@ -379,7 +379,11 @@ def _start_slave(client, config=None):
     try:
         slave_info = client.show_slave_status()
         if slave_info and slave_info['exec_master_log_pos'] != config['slave_master_log_pos']:
-            LOG.warning("ALERT! Slave position changed during backup")
+            LOG.warning("Sanity check on slave status failed.  "
+                    "Previously recorded %s:%d but currently found %s:%d",
+                    config['slave_master_log_file'], config['slave_master_log_pos'],
+                    slave_info['relay_master_log_file'], slave_info['exec_master_log_pos'])
+            LOG.warning("ALERT! Slave position changed during backup!")
     except MySQLError, exc:
         LOG.warning("Failed to sanity check replication[%d]: %s",
                          *exc.args)


### PR DESCRIPTION
Log recorded/found relay_master_log_file/exec_master_log_pos and mimic master status sanity check


Currently:

2017-02-13 23:09:43,502 [WARNING] ALERT! Slave position changed during backup

PR Sample:

2017-02-13 23:09:43,502 [WARNING] Sanity check on slave status failed.  Previously recorded bin-log.000053:2951 but currently found bin-log.000055:120
2017-02-13 23:09:43,502 [WARNING] ALERT! Slave position changed during backup!