### PR TITLE
Mysql float/decimal cast patch 1

### DIFF
--- a/holland/core/backup/base.py
+++ b/holland/core/backup/base.py
@@ -132,11 +132,11 @@ class BackupRunner(object):
 
         spool_entry.config['holland:backup']['stop-time'] = time.time()
         if not dry_run and not spool_entry.config['holland:backup']['failed']:
-            final_size = directory_size(spool_entry.path)
+            final_size = float(directory_size(spool_entry.path))
             LOG.info("Final on-disk backup size %s", format_bytes(final_size))
             if estimated_size > 0:
                 LOG.info("%.2f%% of estimated size %s",
-                     (float(final_size) / estimated_size)*100.0,
+                     (final_size / estimated_size)*100.0,
                      format_bytes(estimated_size))
 
             spool_entry.config['holland:backup']['on-disk-size'] = final_size
@@ -184,7 +184,7 @@ class BackupRunner(object):
             if available_bytes > required_bytes:
                 break
         else:
-            LOG.info("Purging would only recover an additional %s", 
+            LOG.info("Purging would only recover an additional %s",
                      format_bytes(sum(to_purge.values())))
             LOG.info("Only %s total would be available, but the current "
                      "backup requires %s",
@@ -210,12 +210,12 @@ class BackupRunner(object):
     def check_available_space(self, plugin, spool_entry, dry_run=False):
         available_bytes = disk_free(spool_entry.path)
 
-        estimated_bytes_required = plugin.estimate_backup_size()
+        estimated_bytes_required = float(plugin.estimate_backup_size())
         LOG.info("Estimated Backup Size: %s",
                  format_bytes(estimated_bytes_required))
 
         config = plugin.config['holland:backup']
-        adjustment_factor = config['estimated-size-factor']
+        adjustment_factor = float(config['estimated-size-factor'])
         adjusted_bytes_required = (estimated_bytes_required*adjustment_factor)
 
         if adjusted_bytes_required != estimated_bytes_required:
@@ -224,7 +224,7 @@ class BackupRunner(object):
                      format_bytes(adjusted_bytes_required))
 
         if available_bytes <= adjusted_bytes_required:
-            if not (config['purge-on-demand'] and 
+            if not (config['purge-on-demand'] and
                     self.free_required_space(spool_entry.backupset,
                                          adjusted_bytes_required,
                                          dry_run)):
@@ -236,4 +236,4 @@ class BackupRunner(object):
                 LOG.error(msg)
                 if not dry_run:
                     raise BackupError(msg)
-        return estimated_bytes_required
+        return float(estimated_bytes_required)

--- a/holland/core/util/fmt.py
+++ b/holland/core/util/fmt.py
@@ -28,13 +28,13 @@ def format_bytes(bytes, precision=2):
         raise ArithmeticError("Only Positive Integers Allowed")
 
     if bytes != 0:
-        exponent = math.floor(math.log(bytes, 1024))
+        exponent = float(math.floor(math.log(bytes, 1024)))
     else:
-        exponent = 0
+        exponent = float(0)
 
     return "%.*f%s" % (
         precision,
-        bytes / (1024 ** exponent),
+        float(bytes) / (1024 ** exponent),
         ['B','KB','MB','GB','TB','PB','EB','ZB','YB'][int(exponent)]
     )
 

--- a/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
+++ b/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
@@ -103,6 +103,7 @@ class MySQLDumpPlugin(object):
 
     def estimate_backup_size(self):
         """Estimate the size of the backup this plugin will generate"""
+
         LOG.info("Estimating size of mysqldump backup")
         estimate_method = self.config['mysqldump']['estimate-method']
 
@@ -125,7 +126,7 @@ class MySQLDumpPlugin(object):
                 LOG.error("Failed to estimate backup size")
                 LOG.error("[%d] %s", *exc.args)
                 raise BackupError("MySQL Error [%d] %s" % exc.args)
-            return sum([db.size for db in self.schema.databases])
+            return float(sum([db.size for db in self.schema.databases]))
         finally:
             self.client.disconnect()
 


### PR DESCRIPTION
In certain circumstances connecting to remote DBaaS instances (Rackspace Cloud DB, MariaDB 10.1, Holland running on Ubuntu 14.04), the size checks/estimates (disk space, backup size estimate, backup size estimate adjustment, bytes format) are then a mix of Decimal and floats values which produce decimal/float errors when performing arithmetic. 

Resulting in the following errors:
```
Uncaught exception while running command 'bk': TypeError("unsupported operand type(s) for *: 'Decimal' and 'float'",)
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/holland/core/command/command.py", line 209, in dispatch
    return self.run(self.optparser.prog, opts, *args)
  File "/usr/lib/python2.7/dist-packages/holland/commands/backup.py", line 102, in run
    runner.backup(name, config, opts.dry_run)
  File "/usr/lib/python2.7/dist-packages/holland/core/backup/base.py", line 120, in backup
    estimated_size = self.check_available_space(plugin, spool_entry, dry_run)
  File "/usr/lib/python2.7/dist-packages/holland/core/backup/base.py", line 219, in check_available_space
    adjusted_bytes_required = (estimated_bytes_required*adjustment_factor)
TypeError: unsupported operand type(s) for *: 'Decimal' and 'float'


Uncaught exception while running command 'bk': TypeError("unsupported operand type(s) for /: 'float' and 'Decimal'",)
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/holland/core/command/command.py", line 209, in dispatch
    return self.run(self.optparser.prog, opts, *args)
  File "/usr/lib/python2.7/dist-packages/holland/commands/backup.py", line 102, in run
    runner.backup(name, config, opts.dry_run)
  File "/usr/lib/python2.7/dist-packages/holland/core/backup/base.py", line 120, in backup
    estimated_size = self.check_available_space(plugin, spool_entry, dry_run)
  File "/usr/lib/python2.7/dist-packages/holland/core/backup/base.py", line 224, in check_available_space
    format_bytes(adjusted_bytes_required))
  File "/usr/lib/python2.7/dist-packages/holland/core/util/fmt.py", line 38, in format_bytes
    bytes / Decimal(1024 ** exponent),
TypeError: unsupported operand type(s) for /: 'float' and 'Decimal'



Uncaught exception while running command 'bk': TypeError("unsupported operand type(s) for /: 'Decimal' and 'float'",)
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/holland/core/command/command.py", line 209, in dispatch
    return self.run(self.optparser.prog, opts, *args)
  File "/usr/lib/python2.7/dist-packages/holland/commands/backup.py", line 102, in run
    runner.backup(name, config, opts.dry_run)
  File "/usr/lib/python2.7/dist-packages/holland/core/backup/base.py", line 120, in backup
    estimated_size = self.check_available_space(plugin, spool_entry, dry_run)
  File "/usr/lib/python2.7/dist-packages/holland/core/backup/base.py", line 215, in check_available_space
    format_bytes(estimated_bytes_required))
  File "/usr/lib/python2.7/dist-packages/holland/core/util/fmt.py", line 37, in format_bytes
    bytes / (1024 ** exponent),
TypeError: unsupported operand type(s) for /: 'Decimal' and 'float'
```
Initial fix was to cast all as decimal but this is not compatible with a) what was already in place, b) the math being performed.

The patch now forces float() on the relevant variables prior to any arithmetic being performed so there are no decimal values.



