### PR TITLE
Added option to copy datadir instead of tar for LVM snapshots.

### DIFF
--- a/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/actions/__init__.py
+++ b/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/actions/__init__.py
@@ -1,2 +1,3 @@
 from holland.backup.mysql_lvm.actions.mysql import *
 from holland.backup.mysql_lvm.actions.tar import *
+from holland.backup.mysql_lvm.actions.dir import *

--- a/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/actions/dir.py
+++ b/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/actions/dir.py
@@ -1,0 +1,49 @@
+import os
+import time
+import shlex
+import signal
+import logging
+from subprocess import list2cmdline, Popen, CalledProcessError
+from holland.core.exceptions import BackupError
+
+LOG = logging.getLogger(__name__)
+
+class DirArchiveAction(object):
+    def __init__(self, snap_datadir, backup_datadir, config):
+        self.snap_datadir = snap_datadir
+        self.backup_datadir = backup_datadir
+        self.config = config
+
+    def __call__(self, event, snapshot_fsm, snapshot_vol):
+        argv = [
+            'cp',
+            '--archive',
+            self.snap_datadir,
+            '-t',
+            self.backup_datadir
+        ]
+
+        LOG.info("Running: %s ", list2cmdline(argv))
+        archive_log = os.path.join(self.backup_datadir, '../archive.log')
+
+        process = Popen(argv,
+                        preexec_fn=os.setsid,
+                        stdout=open(archive_log, 'w'),
+                        stderr=open(archive_log, 'w'),
+                        close_fds=True)
+        while process.poll() is None:
+            if signal.SIGINT in snapshot_fsm.sigmgr.pending:
+                os.kill(process.pid, signal.SIGKILL)
+            time.sleep(0.5)
+
+        if signal.SIGINT in snapshot_fsm.sigmgr.pending:
+            raise KeyboardInterrupt("Interrupted")
+
+        if process.returncode != 0:
+            LOG.error("tar exited with non-zero status: %d",
+                      process.returncode)
+            LOG.error("Tailing up to the last 10 lines of archive.log for "
+                      "troubleshooting:")
+            for line in open(archive_log, 'r').readlines()[-10:]:
+                LOG.error(" ! %s", line.rstrip())
+            raise CalledProcessError(process.returncode, "tar")

--- a/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/plugin/raw/plugin.py
+++ b/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/plugin/raw/plugin.py
@@ -38,6 +38,9 @@ lock-tables = boolean(default=yes)
 #          run flush tables with read lock
 extra-flush-tables = boolean(default=yes)
 
+# default: create tar file from snapshot
+archive-method      = option(dir,tar,default="tar")
+
 [mysqld]
 mysqld-exe              = force_list(default=list('mysqld', '/usr/libexec/mysqld'))
 user                    = string(default='mysql')

--- a/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/plugin/raw/util.py
+++ b/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/plugin/raw/util.py
@@ -8,7 +8,8 @@ from holland.lib.compression import open_stream
 from holland.backup.mysql_lvm.actions import FlushAndLockMySQLAction, \
                                              RecordMySQLReplicationAction, \
                                              InnodbRecoveryAction, \
-                                             TarArchiveAction
+                                             TarArchiveAction, \
+                                             DirArchiveAction
 from holland.backup.mysql_lvm.plugin.common import log_final_snapshot_size, \
                                                    connect_simple
 from holland.backup.mysql_lvm.plugin.innodb import MySQLPathInfo, check_innodb
@@ -54,17 +55,27 @@ def setup_actions(snapshot, config, client, snap_datadir, spooldir):
         mysqld_config['innodb-log-file-size'] = ib_log_size
         act = InnodbRecoveryAction(mysqld_config)
         snapshot.register('post-mount', act, priority=100)
+    if config['mysql-lvm']['archive-method'] == "dir":
+        try:
+            backup_datadir = os.path.join(spooldir, 'backup_data')
+            os.mkdir(backup_datadir)
+        except OSError, exc:
+            raise BackupError("Unable to create archive directory '%s': %s" %
+                            (backup_datadir, exc))
 
-    try:
-        archive_stream = open_stream(os.path.join(spooldir, 'backup.tar'),
-                                     'w',
-                                     method=config['compression']['method'],
-                                     level=config['compression']['level'],
-                                     extra_args=config['compression']['options'])
-    except OSError, exc:
-        raise BackupError("Unable to create archive file '%s': %s" %
-                          (os.path.join(spooldir, 'backup.tar'), exc))
-    act = TarArchiveAction(snap_datadir, archive_stream, config['tar'])
-    snapshot.register('post-mount', act, priority=50)
+        act = DirArchiveAction(snap_datadir, backup_datadir, config['tar'])
+        snapshot.register('post-mount', act, priority=50)
+    else:
+        try:
+            archive_stream = open_stream(os.path.join(spooldir, 'backup.tar'),
+                                        'w',
+                                        method=config['compression']['method'],
+                                        level=config['compression']['level'],
+                                        extra_args=config['compression']['options'])
+        except OSError, exc:
+            raise BackupError("Unable to create archive file '%s': %s" %
+                            (os.path.join(spooldir, 'backup.tar'), exc))
+        act = TarArchiveAction(snap_datadir, archive_stream, config['tar'])
+        snapshot.register('post-mount', act, priority=50)
 
     snapshot.register('pre-remove', log_final_snapshot_size)


### PR DESCRIPTION
Copying the datadir instead of just tar'ing it up from the LVM snapshot has some advantages with coupled with an external backup system.

Advantages:
Plain copies with a backup system which supports de-duplication can be much faster in the file-per-table. If the table hasn't actually changed since the last backup, it can recognize this instead of being at some varying offset inside the tar due to other changes.
The external "cp -a" vs the internal tar file generation seems to be faster on average.
Restores don't require the unpack step and the extra space that would involve.

Compared to just backing up the LVM snapshot directly rather than copying to holland's spool directory:
It frees the the snapshot more quickly so the system doesn't have to handle Copy-on-Write's extra I/O penalty for as long while it trickles off over the network. 
It can keep a local copy.
