### PR TITLE
add setuptools requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(name="holland",
       install_requires=[
          #'configobj', # currently this is bundled internally
          'future',
+         'setuptools',
          'six'
       ],
       entry_points="""


### PR DESCRIPTION
Holland makes heavy use of the pkg_resources module, which is part of setuptools.