### PR TITLE
Remove `future` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(name="holland",
       test_suite='tests',
       install_requires=[
          #'configobj', # currently this is bundled internally
-         'future',
          'setuptools',
          'six'
          #'argparse'   #Not built into python2.6


### PR DESCRIPTION
The project is using the standard library `__future__`, not the `future` module from PyPI.