### PR TITLE
mysql/PassiveMySQLClient: really defer mysql connection until connect()

### DIFF
--- a/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
+++ b/plugins/holland.lib.mysql/holland/lib/mysql/client/base.py
@@ -437,7 +437,6 @@ class PassiveMySQLClient(MySQLClient):
         self._connection = None
         self._args = args
         self._kwargs = kwargs
-        super(PassiveMySQLClient, self).__init__()
 
     def connect(self):
         """Connect to MySQL using the connection parameters this instance


### PR DESCRIPTION
Original code called MySQLClient.__init__(), which calls MySQLdb.connect()
to immediately open connection and does nothing else. Problem is that
__init__() is called without args/kwargs, which results connection with
no username or password. That fails if "root" user requires password,
making plugin to fail.

Removing this super(...).__init__() fixed mysqldump-plugin for me. You know the code better, does it break something else? It should not. Another option is to change this line to super(...).__init__(*args, **kwargs), but then connection is not deferred.