### PR TITLE
Fix error caused by rewriting the which command

### DIFF
--- a/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/actions/mysql/_mysqld.py
+++ b/plugins/holland.backup.mysql_lvm/holland/backup/mysql_lvm/actions/mysql/_mysqld.py
@@ -15,14 +15,12 @@ LOG = logging.getLogger(__name__)
 def locate_mysqld_exe(config):
     mysqld_candidates = config.pop('mysqld-exe')
     for candidate in mysqld_candidates:
-        if os.path.isabs(candidate):
-            path = [os.path.dirname(candidate)]
-            candidate = os.path.basename(candidate)
-        else:
-            path = None # use environ[PATH]
-        LOG.debug("Searching for %s on path %s",
-                  candidate, path or os.environ['PATH'])
-        return which(candidate)
+        if os.path.isfile(candidate):
+	    return candidate
+	try:
+	    return which(candidate)
+	except BackupError:
+            pass
     raise BackupError("Failed to find mysqld binary")
 
 class MySQLServer(object):

--- a/plugins/holland.lib.common/holland/lib/which.py
+++ b/plugins/holland.lib.common/holland/lib/which.py
@@ -16,8 +16,9 @@ def which(cmd):
             #shutil.which was added in python 3.3
             for path in os.environ['PATH'].split(':'):
                 try:
-                    if any(ls.startswith(cmd) for ls in os.listdir(path)):
-                        return os.path.join(path, cmd)
+                    for ls in os.listdir(path):
+                        if cmd == ls:
+                            return os.path.join(path, cmd)
                 except OSError:
                     pass
-    raise BackupError("No command found for compression method '%s'" % cmd)
+    raise BackupError("No command found '%s'" % cmd)


### PR DESCRIPTION
The last version of 'which' wasn't strict enough. It would match `mysqld` and `mysqld_safe`.  This is looking for an exact match. Also discovered that mysql-lvm plugin was passing two arguments into the which function. 