### PR TITLE
fix arg parse errors in mk_config command

### DIFF
--- a/holland/commands/mk_config.py
+++ b/holland/commands/mk_config.py
@@ -130,18 +130,19 @@ class MkConfig(Command):
         },
         {
             'help':'Edit the generated config',
-            'action':'store_true'
+            'action':'store_true',
+            'default': False
         },
         {
             'help':'Generate a provider config'
         },
         {
-            'help':'Save the final config to the specified file',
-            'action':'store_true',
-            'default':False
+            'help':'Save the final config to the specified file'
         },
         {
-            'help':'Do not include comment from a backupplugin\'s configspec'
+            'help':'Do not include comment from a backupplugin\'s configspec',
+            'action':'store_true',
+            'default': False
         }
     ]
 

--- a/scripts/travis_ci.sh
+++ b/scripts/travis_ci.sh
@@ -32,17 +32,22 @@ su -c 'psql -c "CREATE USER root WITH SUPERUSER"' postgres
 
 CMDS=(
 "holland mc --name mysqldump mysqldump"
+"holland mc -f /tmp/mysqldump.conf mysqldump"
 "holland bk mysqldump --dry-run"
 "holland bk mysqldump"
 "holland mc --name xtrabackup xtrabackup"
+"holland mc --file /tmp/xtrabackup.conf xtrabackup"
 "holland bk xtrabackup --dry-run"
 "holland bk xtrabackup"
 "holland mc --name mongodump mongodump"
+"holland mc --file /tmp/mongodump.conf mongodump"
 "holland bk mongodump --dry-run"
 "holland bk mongodump"
 "holland mc --name pgdump pgdump"
+"holland mc --file /tmp/pgdump.conf pgdump"
 "holland bk pgdump --dry-run"
 "holland bk pgdump"
+"holland bk mysqldump xtrabackup"
 "holland_cvmysqlsv -bkplevel 1 -attempt 1 -job 123456 -cn 957072-661129 -vm Instance001 --bkset mysqldump"
 )
 


### PR DESCRIPTION
Fix for bug reported by @mikegriffin 

```
# holland mc mysqldump -f /etc/holland/backupsets/mysqldump.conf
Holland 1.1.8 started with pid 10730
Saving config to True
Failed comamnd holland mk-config': coercing to Unicode: need string or buffer, bool found
```