### PR TITLE
Rework holland commvault wrapper

### DIFF
--- a/contrib/holland-commvault/holland_commvault/__init__.py
+++ b/contrib/holland-commvault/holland_commvault/__init__.py
@@ -1,3 +1,7 @@
+"""
+Wrapper to allow Commvault agent to call Holland
+"""
+
 from .commvault import main
 
 __all__ = [

--- a/contrib/holland-commvault/holland_commvault/commvault.py
+++ b/contrib/holland-commvault/holland_commvault/commvault.py
@@ -119,7 +119,7 @@ def main():
             status.close()
             return ret
     except PidFileAlreadyLockedError:
-        ret =1
+        ret = 1
         pid_file = open(pid_location, 'r')
         pid = pid_file.read()
         pid_file.close()

--- a/contrib/holland-commvault/holland_commvault/commvault.py
+++ b/contrib/holland-commvault/holland_commvault/commvault.py
@@ -129,8 +129,8 @@ def main():
         while os.path.isfile(pid_location):
             sleep(10)
             count = count + 1
-            #10 hour timeout
-            if count > 3600:
+            #~14 hour timeout
+            if count > 5040:
                 logging.info("Holland (commvault agent) timed out after %s seconds", count*10)
                 return 1
         try:

--- a/contrib/holland-commvault/setup.py
+++ b/contrib/holland-commvault/setup.py
@@ -17,6 +17,7 @@ Commvault support command(s)""",
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
+    install_requires=['pid'],
     entry_points="""
     [console_scripts]
     holland_cvmysqlsv = holland_commvault:main

--- a/scripts/travis_ci.sh
+++ b/scripts/travis_ci.sh
@@ -11,7 +11,7 @@ fi
 if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]
 then
     pylint_failed=0
-    for d in $(ls -d ./plugins/*/holland)
+    for d in $(ls -d ./plugins/*/holland ./contrib/holland-commvault/holland_commvault)
     do
         pylint $d
         if [ $? -ne 0 ] && [ $pylint_failed -ne 1 ]


### PR DESCRIPTION
- Lint files
- Add holland_commvault module to pylint list in Travis CI
- Add logic so the commvault wrapper will wait for another instance of the wrapper to complete, and then return the other processes return code. This uses the commvault 'job' id, which is expected to be different for distant runs and backup sets.

(requires pid module)