### PR TITLE
 Add 'maintenance' option to the backup command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,13 +8,14 @@ http://bugs.launchpad.net/holland-backup
 GH# referes to the deprecated github bug tracker here:
 https://github.com/holland-backup/holland/issues
 
-1.1.12 - Feb 1, 2019
+1.1.12 - Feb 7, 2019
 ---------------------
 
 holland
 +++++++
 
-- Start on new release
+- Bug fixes #269, 267
+- Add support for xtrabackup 8.0
 
 1.1.11 - Jan 23, 2019
 ---------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ holland
 
 - Bug fixes #269, 267
 - Add support for xtrabackup 8.0
+- Add --maint/--skip-purge to the backup command
 
 1.1.11 - Jan 23, 2019
 ---------------------

--- a/contrib/holland-commvault/holland_commvault/commvault.py
+++ b/contrib/holland-commvault/holland_commvault/commvault.py
@@ -108,6 +108,7 @@ def main():
     args.dry_run = 0
     args.no_lock = 0
     args.maint = 0
+    args.skip_purge = 0
     largs = args.bksets
     spool = HOLLANDCFG.lookup("holland.backup-directory")
     status_file = "%s/%s/newest/job_%s" % (spool, args.bksets[0], args.job)

--- a/holland/commands/backup.py
+++ b/holland/commands/backup.py
@@ -32,7 +32,13 @@ class Backup(Command):
 
     aliases = ["bk"]
 
-    args = [["--abort-immediately"], ["--dry-run", "-n"], ["--no-lock", "-f"], ["--maint"]]
+    args = [
+        ["--abort-immediately"],
+        ["--dry-run", "-n"],
+        ["--no-lock", "-f"],
+        ["--maint"],
+        ["--skip-purge", "-s"],
+    ]
     kargs = [
         {"action": "store_true", "help": "Abort on the first backupset that fails."},
         {"action": "store_true", "help": "Print backup commands without executing them."},
@@ -45,6 +51,7 @@ class Backup(Command):
             "action": "store_true",
             "help": "Create a maintenance backup. Ignore 'backups-to-keep' setting, and create a single file backup if the plugin supports it",
         },
+        {"action": "store_true", "help": "Don't purge backups"},
     ]
     description = "Run backups for active backupsets"
 
@@ -71,7 +78,10 @@ class Backup(Command):
         # don't purge if doing a dry-run,
         # when simultaneous backups may be running,
         # or when creating a mintenace backup
-        if not opts.no_lock and not opts.maint:
+        if opts.maint:
+            opts.skip_purge = True
+
+        if not opts.no_lock and not opts.skip_purge:
             purge_mgr = PurgeManager()
 
             runner.register_cb("before-backup", purge_mgr)

--- a/holland/core/spool.py
+++ b/holland/core/spool.py
@@ -258,6 +258,7 @@ failed-backup-command   = string(default=None)
 historic-size           = boolean(default=yes)
 historic-size-factor    = float(default=1.5)
 historic-estimated-size-factor = float(default=1.1)
+maintenance             = boolean(default=no)
 """.splitlines()
 
 

--- a/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
+++ b/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
@@ -175,6 +175,9 @@ class MySQLDumpPlugin(object):
             status = self.client.show_databases()
             if not status:
                 raise BackupError("Failed to run 'show databases'")
+        if self.config["holland:backup"]["maintenance"]:
+            LOG.info("Requested maintenace backup, set 'file-per-database' to False")
+            self.config["mysqldump"]["file-per-database"] = False
         try:
             if self.config["mysqldump"]["stop-slave"]:
                 slave_status = self.client.show_slave_status()


### PR DESCRIPTION
This allows users to create a one off backups without purging existing backups. This will also cause the mysqldump plugin to run with `file-per-database = false`. 
This could be useful for user's that want to dump and load their databases without effecting existing backups. 