### PR TITLE
mongodump: add support for "uri" config option

### DIFF
--- a/config/providers/mongodump.conf
+++ b/config/providers/mongodump.conf
@@ -4,6 +4,11 @@ username               =
 password               =
 authenticationDatabase =
 
+## Instead of above "host/username/password" parameters "uri" parameter can
+## be used. It must be full MongoDB connect uri. It allows more fine grained
+## connection setup.
+#uri =
+
 ## any additional options to the 'mongodump' command-line utility
 ## these should show up exactly as they are on the command line
 ## e.g.: --gzip


### PR DESCRIPTION
Current "host/username/password" options are fine for single MongoDB
node setup. MongoDB cluster with replication needs more fine tuned
setup, for example:

uri = mongodb://user:pass@host1,host2,host3?replicaSet=setname&readPreference=primaryPreferred

With this change you can still use "host/username/password" as
previously, or replace them all with single "uri" parameter. If both
are defined, then "uri" will be used.