### PR TITLE
Remove role option that doesn't exist in pg_basebackup

### DIFF
--- a/config/providers/pg_basebackup.conf
+++ b/config/providers/pg_basebackup.conf
@@ -3,7 +3,6 @@
 format = tar
 wal-method = fetch
 checkpoint = fast
-# role = "" # no default
 # additional-options = "" # no default
 
 [pgauth]

--- a/plugins/holland.backup.pg_basebackup/holland/backup/pg_basebackup/base.py
+++ b/plugins/holland.backup.pg_basebackup/holland/backup/pg_basebackup/base.py
@@ -48,13 +48,6 @@ def get_connection(config, pgdb="template1"):
     # set connection in autocommit mode
     connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
 
-    if config["pg-basebackup"]["role"]:
-        try:
-            cursor = connection.cursor()
-            cursor.execute("SET ROLE %s" % config["pg-basebackup"]["role"])
-        except:
-            raise PgError("Failed to set role to " + config["pg-basebackup"]["role"])
-
     global VER  # pylint: disable=W0603
     VER = connection.get_parameter_status("server_version")
     LOG.info("Server version %s", VER)
@@ -196,14 +189,6 @@ def pgauth2args(config):
         key = remap.get(param, param)
         if value is not None:
             args.extend(["--%s" % key, str(value)])
-
-    if config["pg-basebackup"]["role"]:
-        if VER >= "8.4":
-            args.extend(["--role", config["pg-basebackup"]["role"]])
-        else:
-            raise PgError(
-                "The --role option is available only in Postgres" " versions 8.4 and higher."
-            )
 
     return args
 

--- a/plugins/holland.backup.pg_basebackup/holland/backup/pg_basebackup/interface.py
+++ b/plugins/holland.backup.pg_basebackup/holland/backup/pg_basebackup/interface.py
@@ -36,7 +36,6 @@ CONFIGSPEC = (
 format = option('tar','plain',default='tar')
 wal-method = option('none','fetch','stream',default='fetch')
 checkpoint = option('none','fast','spread',default='fast')
-role = string(default=None)
 additional-options = string(default=None)
 
 [pgauth]


### PR DESCRIPTION
Remove role argument from pg_basebackup plugin