### PR TITLE
Allow choice between `mbstream` and `xbstream`

### DIFF
--- a/plugins/holland.backup.mariabackup/holland/backup/mariabackup/util.py
+++ b/plugins/holland.backup.mariabackup/holland/backup/mariabackup/util.py
@@ -136,7 +136,7 @@ def determine_stream_method(stream):
     """Calculate the stream option from the holland config"""
     stream = stream.lower()
     if stream in ("mbstream", "xbstream"):
-        return "xbstream"
+        return stream
     if stream in ("no", "0", "false"):
         return None
     raise BackupError("Invalid mariabackup stream method '%s'" % stream)


### PR DESCRIPTION
`xbstream` has been renamed to `mbstream` to avoid clash with Percona utility, so an explicit choice of `mbstream` should be adhered to.

https://jira.mariadb.org/browse/MDEV-15730