### PR TITLE
mongodump: fix compatibility with latest PyMongo

### DIFF
--- a/plugins/holland.backup.mongodump/holland/backup/mongodump.py
+++ b/plugins/holland.backup.mongodump/holland/backup/mongodump.py
@@ -76,7 +76,7 @@ class MongoDump(object):
                 uri += "@"
             uri += self.config["mongodump"].get("host")
         client = MongoClient(uri)
-        dbs = client.database_names()
+        dbs = client.list_database_names()
         for database in dbs:
             c_db = client[database]
             tup = c_db.command("dbstats")

--- a/plugins/holland.backup.mongodump/setup.py
+++ b/plugins/holland.backup.mongodump/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(exclude=["ez_setup", "examples", "tests", "tests.*"]),
     namespace_packages=["holland", "holland.backup"],
     zip_safe=True,
-    install_requires=["pymongo"],
+    install_requires=["pymongo>=3.6"],
     # holland looks for plugins in holland.backup
     entry_points="""
       [holland.backup]


### PR DESCRIPTION
PyMongo version 3.6 adds list_database_names() and version 4.0 removes database_names().