### PR TITLE
Silence pkg_resources deprecation warning

### DIFF
--- a/holland/commands/__init__.py
+++ b/holland/commands/__init__.py
@@ -2,4 +2,12 @@
 Define command plugins
 """
 
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    category=DeprecationWarning,
+    message="pkg_resources is deprecated as an API.*",
+)
+
 __import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
Relates to https://github.com/holland-backup/holland/issues/362

Removal of `pkg_resources` will require us to refactor the plugin loading a bit and will be pushed to the next major version update to holland. In the short-term we've elected to silence the deprecation warning as there is a desire to tag a new release soon.

@mikegriffin Not sure if you have cycles to test this - but I believe this should be sufficient.