### PR TITLE
Allow values without a suffix to be interpreted as bytes

### DIFF
--- a/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
+++ b/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
@@ -567,10 +567,14 @@ def parse_size(units_string):
 
     units = "kKmMgGtTpPeE"
 
-    match = re.match(r"^(\d+(?:[.]\d+)?)([%s])$" % units, units_string)
+    match = re.match(r"^(\d+(?:[.]\d+)?)([%s]?)$" % units, units_string)
     if not match:
         raise ValueError("Invalid constant size syntax %r" % units_string)
     number, unit = match.groups()
+
+    if not unit:
+       return int(float(number))
+
     unit = unit.upper()
 
     exponent = "KMGTPE".find(unit)


### PR DESCRIPTION
Fixes https://github.com/holland-backup/holland/issues/382.

Initially I was going to allow it to accept Bb as a suffix but it seems more consistent to just interpret no suffix as correlating to bytes instead.