### PR TITLE
Fix output filename for xtrabackup > 8.0 when using stream=yes and use preferred mariadb-backup binary

### DIFF
--- a/plugins/holland.backup.mariabackup/holland/backup/mariabackup/plugin.py
+++ b/plugins/holland.backup.mariabackup/holland/backup/mariabackup/plugin.py
@@ -106,7 +106,8 @@ class MariabackupPlugin(object):
         mb_cfg = self.config["mariabackup"]
         args = util.build_mb_args(mb_cfg, self.target_directory, self.defaults_path)
         LOG.info("* mariabackup command: %s", list2cmdline(args))
-        args = ["mariabackup", "--defaults-file=" + self.defaults_path, "--help"]
+        bin_path = util.get_mariadb_backup_bin_path(self.config)
+        args = [bin_path, "--defaults-file=" + self.defaults_path, "--help"]
         cmdline = list2cmdline(args)
         LOG.info("* Verifying generated config '%s'", self.defaults_path)
         LOG.debug("* Verifying via command: %s", cmdline)

--- a/plugins/holland.backup.mariabackup/holland/backup/mariabackup/plugin.py
+++ b/plugins/holland.backup.mariabackup/holland/backup/mariabackup/plugin.py
@@ -106,7 +106,7 @@ class MariabackupPlugin(object):
         mb_cfg = self.config["mariabackup"]
         args = util.build_mb_args(mb_cfg, self.target_directory, self.defaults_path)
         LOG.info("* mariabackup command: %s", list2cmdline(args))
-        bin_path = util.get_mariadb_backup_bin_path(self.config)
+        bin_path = util.get_mariadb_backup_bin_path(mb_cfg)
         args = [bin_path, "--defaults-file=" + self.defaults_path, "--help"]
         cmdline = list2cmdline(args)
         LOG.info("* Verifying generated config '%s'", self.defaults_path)
@@ -127,11 +127,11 @@ class MariabackupPlugin(object):
 
     def backup(self):
         """Perform Backup"""
-        util.mariabackup_version()
+        mb_cfg = self.config["mariabackup"]
+        util.mariabackup_version(mb_cfg)
         if self.dry_run:
             self.dryrun()
             return
-        mb_cfg = self.config["mariabackup"]
         backup_directory = self.target_directory
         tmpdir = util.evaluate_tmpdir(mb_cfg["tmpdir"], backup_directory)
         # innobackupex --tmpdir does not affect mariabackup

--- a/plugins/holland.backup.mariabackup/holland/backup/mariabackup/plugin.py
+++ b/plugins/holland.backup.mariabackup/holland/backup/mariabackup/plugin.py
@@ -92,12 +92,7 @@ class MariabackupPlugin(object):
         backup_directory = self.target_directory
         stream = util.determine_stream_method(config["stream"])
         if stream:
-            if stream == "tar":
-                archive_path = join(backup_directory, "backup.tar")
-            elif "stream" in stream:
-                archive_path = join(backup_directory, "backup.mb")
-            else:
-                raise BackupError("Unknown stream method '%s'" % stream)
+            archive_path = join(backup_directory, "backup.mb")
             try:
                 return open_stream(archive_path, "w", **self.config["compression"])
             except OSError as exc:

--- a/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
+++ b/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
@@ -26,7 +26,7 @@ CONFIGSPEC = (
 global-defaults     = string(default='/etc/my.cnf')
 innobackupex        = string(default='innobackupex')
 ibbackup            = string(default=None)
-stream              = string(default=tar)
+stream              = string(default=xbstream)
 apply-logs          = boolean(default=yes)
 slave-info          = boolean(default=no)
 safe-slave-backup   = boolean(default=no)

--- a/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
+++ b/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/plugin.py
@@ -89,11 +89,11 @@ class XtrabackupPlugin(object):
         except IOError as exc:
             raise BackupError("[%d] %s" % (exc.errno, exc.strerror))
 
-    def open_xb_stdout(self):
+    def open_xb_stdout(self, binary_xtrabackup=False):
         """Open the stdout output for a streaming xtrabackup run"""
         config = self.config["xtrabackup"]
         backup_directory = self.target_directory
-        stream = util.determine_stream_method(config["stream"])
+        stream = util.determine_stream_method(config["stream"], binary_xtrabackup=binary_xtrabackup)
         if stream:
             if stream == "tar":
                 archive_path = join(backup_directory, "backup.tar")
@@ -157,7 +157,7 @@ class XtrabackupPlugin(object):
         )
         stderr = self.open_xb_logfile()
         try:
-            stdout = self.open_xb_stdout()
+            stdout = self.open_xb_stdout(binary_xtrabackup=binary_xtrabackup)
             exc = None
             try:
                 try:

--- a/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/util.py
+++ b/plugins/holland.backup.xtrabackup/holland/backup/xtrabackup/util.py
@@ -89,7 +89,7 @@ def apply_xtrabackup_logfile(xb_cfg, backupdir, binary_xtrabackup=False):
     """
     # run ${innobackupex} --apply-log ${backupdir}
     # only applies when streaming is not used
-    stream_method = determine_stream_method(xb_cfg["stream"])
+    stream_method = determine_stream_method(xb_cfg["stream"], binary_xtrabackup=binary_xtrabackup)
     if stream_method is not None:
         LOG.warning("Skipping --prepare/--apply-logs since backup is streamed")
         return
@@ -121,11 +121,12 @@ def apply_xtrabackup_logfile(xb_cfg, backupdir, binary_xtrabackup=False):
         raise BackupError("%s returned failure status [%d]" % (cmdline, process.returncode))
 
 
-def determine_stream_method(stream):
+def determine_stream_method(stream, binary_xtrabackup=False):
     """Calculate the stream option from the holland config"""
     stream = stream.lower()
+    # For xtrabackup >= 8.0 settings of tar/tar4idb/yes/1/true are ignored and force the use of xbstream
     if stream in ("yes", "1", "true", "tar", "tar4ibd"):
-        return "tar"
+        return "xbstream" if binary_xtrabackup else "tar"
     if stream in ("xbstream",):
         return "xbstream"
     if stream in ("no", "0", "false"):
@@ -192,7 +193,7 @@ def build_xb_args(config, basedir, defaults_file=None, binary_xtrabackup=False):
             innobackupex = which(innobackupex)
 
     ibbackup = config["ibbackup"]
-    stream = determine_stream_method(config["stream"])
+    stream = determine_stream_method(config["stream"], binary_xtrabackup=binary_xtrabackup)
     tmpdir = evaluate_tmpdir(config["tmpdir"], basedir)
     slave_info = config["slave-info"]
     safe_slave_backup = config["safe-slave-backup"]


### PR DESCRIPTION
Fixes #372.

Changes:

- Defaults the xtrabckup stream to xbstream when using mk-config
- In holland-xtrabackup - when using `stream=yes` and using xtrabackup > 8.0 - backup files would be written as `backup.tar.<compressor>` even though xbstream is being forced. The `determine_stream_method` has been updated to account for this and properly returns `xbstream` in this scenario. This should result in the proper filenames being written.
- In holland-mariabackup - the `open_mb_stdout` had a branch section that suggested `tar` was a valid stream option. This branch was removed as `determine_stream_method` only allows for `mbstream/xbstream` as config options.
- In holland-mariabackup - mariabackup has been symlinked to `mariadb-backup` in versions 10.4 and greater and generates a warning when using the symlinked name. A new `get_mariadb_backup_bin_path` has been added to first check if `mariadb-backup` exists first and will return that path if found. Otherwise we fall back to `mariabackup` if the former was not found. Also handles other potential values that the config maybe set to.