### PR TITLE
Install pymongo upfront to avoid issue with pymongo installing via setup.py

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,8 @@ apt-get install -y python3-pip python3-psycopg2 rsync
 pip3 install configobj
 pip3 install 'pylint>=2.17.0,<3.0.0'
 pip3 install six
+# Install pymongo with pip to get around error when holland-monogodump is installed via setup.py
+pip3 install 'pymongo>=3.6'
 python3 --version'''
       }
     }


### PR DESCRIPTION
Currently jenkins builds are failing due to how we currently install holland with setup.py. 

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/f5f2943a-92a3-4638-abdf-5d4981d2e96c" />

This is just a temporary workaround that installs pymongo via pip upfront in our Jenkinsfile to try and avoid encountering this issue.