### PR TITLE
Add new holland mariadb-dump plugin and various bug fixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,7 +68,7 @@ Please see their documentation for details on how to install and use these conta
 ### Install base
 ** Requires Python Setuptool
 ```
-# python setup.py install
+# python3 setup.py install
 ```
 
 ### Create documentation
@@ -78,23 +78,23 @@ Please see their documentation for details on how to install and use these conta
 # cp ${TARGET}/holland/build/man/holland.1 /usr/share/man/man1/
 ```
 
-### Install common plugins
+### Install holland.lib.common plugin
 ```
 # cd ${TARGET}/holland/plugins/holland.lib.common/
-# python setup.py install
+# python3 setup.py install
 ```
 
 ### Most plugins require the holland.lib.mysql plugin
 ** The MySQldb connector requires gcc, mysql-devel, and python-devel
 ```
 # cd ${TARGET}/holland/plugins/holland.lib.mysql/
-# python setup.py install
+# python3 setup.py install
 ```
 
 ### Install other plugins
 ```
 # cd ../holland.backup.{plugin name}
-# python setup.py install
+# python3 setup.py install
 ```
 
 ### Setup configuration files

--- a/config/providers/mariadb-dump.conf
+++ b/config/providers/mariadb-dump.conf
@@ -1,0 +1,153 @@
+## Global settings for the mariadb-dump provider - Requires holland-mariadb-dump.
+##
+## Unless overwritten, all backup-sets implementing this provider will use
+## the following settings.
+
+[mariadb-dump]
+
+## This option controls whether mariadb-dump will only read options as set by
+## holland or if additional options from global config files are read. By
+## default, the plugin only uses options as set in the backupset config and
+## includes authentication credentials only from the [client] section in
+## ~/.my.cnf.
+extra-defaults      = no
+
+## Override the path where we can find mariadb command line utilities.
+executable       = "mariadb-dump"
+
+## One of: flush-lock, lock-tables, single-transaction, auto-detect, none.
+##
+## flush-lock will place a global lock on all tables involved in the backup
+## regardless of whether or not they are in the backup-set. If
+## file-per-database is enabled, then flush-lock will lock all tables
+## for every database being backed up. In other words, this option may not
+## make much sense when using file-per-database.
+##
+## lock-tables will lock all tables involved in the backup. If
+## file-per-database is enabled, then lock-tables will only lock all the
+## tables associated with that database.
+##
+## single-transaction will force running a backup within a transaction.
+## This allows backing up of transactional tables without imposing a lock
+## however will NOT properly backup non-transactional tables.
+##
+## Auto-detect will choose single-transaction unless Holland finds
+## non-transactional tables in the backup-set.
+##
+## None will completely disable locking. This is generally only viable
+## on a MariaDB slave and only after traffic has been diverted, or slave
+## services suspended.
+lock-method         = auto-detect
+
+## List of comma-delimited glob patterns for matching databases.
+## Only databases matching these patterns will be backed up.
+## default: include everything.
+#databases           = "*"
+
+## List of comma-delimited glob patterns to exclude particular databases.
+#exclude-databases   =
+
+## List of comma-delimited tables to include.
+#tables              = "*"
+
+## List of comma-delimited tables to exclude.
+#exclude-tables      = ""
+
+## List of comma-delimited glob patterns for matching table engines.
+## Only tables matching these patterns will be backed up.
+## default: include everything.
+#engines             = "*"
+
+## List of comma-delimited glob patterns to exclude particular table engines.
+#exclude-engines     =
+
+## Whether to automate exclusion of invalid views that would otherwise cause
+## mariadb-dump to fail. This adds additional overhead so this option is not
+## enabled by default.
+exclude-invalid-views = no
+
+## Whether to run FLUSH LOGS in MariaDB with the backup. When FLUSH
+## LOGS is actually executed depends on which if database filtering is being
+## used and whether or not file-per-database is enabled. Generally speaking,
+## it does not make sense to use flush-logs with file-per-database since the
+## binary logs will not be consistent with the backup.
+flush-logs			= no
+
+## Whether to emit a FLUSH PRIVILEGES statement after dumping the mysql database.
+## This ensures a proper restore when a dump contains the mysql database.
+flush-privileges    = yes
+
+## Whether to dump routines explicitly.
+## (routines are implicitly included in the mariadb database)
+dump-routines       = yes
+
+## Whether to dump events explicitly.
+dump-events			= no
+
+## Whether to dump history explicitly.
+## Requires MariaDB 10.11.0 or later.
+dump-history		= no
+
+## Whether to dump tables in the order of their size, smaller first.
+## Requires MariaDB 10.9.1 or later.
+order-by-size		= no
+
+## Whether to stop the slave before commencing with the backup.
+stop-slave          = no
+
+## Whether to record the binary log name and position at the time of the backup.
+bin-log-position    = no
+
+## Maximum packet length to send/receive from the server.
+max-allowed-packet  = 128M
+
+## Whether to run a separate 'mariadb-dump' for each database. Note that while
+## this may initially sound like a good idea, it is far simpler to backup
+## all databases in one file, although that makes the restore process
+## more difficult when only certain data needs to be restored.
+file-per-database   = yes
+
+## The args-per-database option is only used if file-per-database is enabled.
+## It takes a JSON string in the format {"table1": "--arg", "table2": "--arg"}.
+# arg-per-database    = {}
+
+## Any additional options to pass to the 'mariadb-dump' command-line utility.
+## These should show up exactly as they are on the command line.
+## e.g.: --flush-privileges --reset-master.
+additional-options  = ""
+
+## Compression Settings
+[compression]
+
+## Compression method: gzip, gzip-rsyncable, bzip2, pbzip2, or lzop.
+## Which compression method to use, which can be either gzip, bzip2, or lzop.
+## Note that lzop is not often installed by default on many Linux
+## distributions and may need to be installed separately.
+method              = gzip
+
+## Whether to compress data as it is provided from 'mariadb-dump', or to
+## compress after a dump has finished. In general, it is often better to use
+## inline compression. The overhead, particularly when using a lower
+## compression level, is often minimal since the entire process is often I/O
+## bound (as opposed to being CPU bound).
+inline              = yes
+
+## What compression level to use. Lower numbers mean faster compression,
+## though also generally a worse compression ratio. Generally, levels 1-3
+## are considered fairly fast and still offer good compression for textual
+## data. Levels above 7 can often cause a larger impact on the system due to
+## needing much more CPU resources. Setting the level to 0 effectively
+## disables compression.
+level               = 1
+
+## MariaDB connection settings. Note that Holland will try to read from
+## the provided files defined in the 'defaults-extra-file', although
+## explicitly defining the connection information here will take precedence.
+[mysql:client]
+
+defaults-extra-file  = /root/.my.cnf,~/.my.cnf,
+#user                = hollandbackup
+#password            = "hollandpw"
+#socket              = /tmp/mysqld.sock
+#host                = localhost
+#port                = 3306

--- a/plugins/holland.backup.mariadb_dump/GPL
+++ b/plugins/holland.backup.mariadb_dump/GPL
@@ -1,0 +1,343 @@
+Copyright (c) 2008-2025 Rackspace US, Inc.
+All rights reserved.
+
+
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/plugins/holland.backup.mariadb_dump/LICENSE
+++ b/plugins/holland.backup.mariadb_dump/LICENSE
@@ -1,0 +1,16 @@
+mariadb-dump Plugin for the Holland Backup Framework
+Copyright (C) 2008-2025  Rackspace US, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/plugins/holland.backup.mariadb_dump/README
+++ b/plugins/holland.backup.mariadb_dump/README
@@ -1,0 +1,12 @@
+This plugin performs logical backups of a MariaDB database by using the
+mariadb-dump command.  Quite a few options are supported including database and
+table filtering through inclusion/exclusion filtering directives.  Table
+exclusions always map to --ignore-table parameters and database exclusions are
+skipped by simply not passing them to the --database flags.
+
+Inline-compression of maria-dump output is supported and the default.  By
+default mechanism uses gzip -1 ("--fast") for fast but reasonable compression.
+bzip2, pbzip2, lzop and lzma (vi xz-utils) are also supported.
+
+For more information please consult the holland manual or visit the holland
+wiki at http://hollandbackup.org.

--- a/plugins/holland.backup.mariadb_dump/holland/__init__.py
+++ b/plugins/holland.backup.mariadb_dump/holland/__init__.py
@@ -1,0 +1,5 @@
+"""
+Define module
+"""
+
+__import__("pkg_resources").declare_namespace(__name__)

--- a/plugins/holland.backup.mariadb_dump/holland/backup/__init__.py
+++ b/plugins/holland.backup.mariadb_dump/holland/backup/__init__.py
@@ -1,0 +1,5 @@
+"""
+Define module
+"""
+
+__import__("pkg_resources").declare_namespace(__name__)

--- a/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/__init__.py
+++ b/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/__init__.py
@@ -1,0 +1,5 @@
+"""Setup Module"""
+
+from holland.backup.mariadb_dump.plugin import CONFIGSPEC, MariaDBDumpPlugin
+
+Provider = MariaDBDumpPlugin

--- a/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/base.py
+++ b/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/base.py
@@ -1,0 +1,154 @@
+"""Main driver"""
+
+import errno
+import json
+import logging
+
+from holland.backup.mariadb_dump.command import ALL_DATABASES
+from holland.core.backup import BackupError
+from holland.lib.safefilename import encode
+
+LOG = logging.getLogger(__name__)
+
+
+def start(
+    mariadb_dump,
+    schema=None,
+    lock_method="auto-detect",
+    file_per_database=True,
+    open_stream=open,
+    compression_ext="",
+    arg_per_database=None,
+):
+    """Start a mariadb-dump backup"""
+    if not schema and file_per_database:
+        raise BackupError("file_per_database specified without a valid schema")
+
+    if not schema:
+        target_databases = ALL_DATABASES
+    else:
+
+        if not schema.databases:
+            raise BackupError("No databases found to backup")
+
+        if not file_per_database and not list(schema.excluded_databases):
+            target_databases = ALL_DATABASES
+        else:
+            target_databases = [db for db in schema.databases if not db.excluded]
+            write_manifest(schema, open_stream, compression_ext)
+
+    if file_per_database:
+        arg_per_database = json.loads(arg_per_database) if arg_per_database else {}
+        flush_logs = "--flush-logs" in mariadb_dump.options
+        if flush_logs:
+            mariadb_dump.options.remove("--flush-logs")
+        for target_db in target_databases:
+            additional_options = [mariadb_dump_lock_option(lock_method, [target_db])]
+            # add --flush-logs only to the last database
+            if flush_logs and target_db == target_databases[-1]:
+                additional_options.append("--flush-logs")
+            db_name = encode(target_db.name)
+            if db_name != target_db.name:
+                LOG.warning(
+                    "Encoding file-name for database %s to %s", target_db.name, db_name
+                )
+
+            if db_name in arg_per_database:
+                additional_options.append(arg_per_database[db_name])
+            run_mariadb_dump(
+                mariadb_dump,
+                open_stream,
+                f"{db_name}.sql",
+                compression_ext,
+                [target_db.name],
+                additional_options,
+            )
+    else:
+        if target_databases is not ALL_DATABASES:
+            target_databases = [db.name for db in target_databases]
+        run_mariadb_dump(
+            mariadb_dump,
+            open_stream,
+            "all_databases.sql",
+            compression_ext,
+            target_databases,
+            additional_options,
+        )
+
+
+def run_mariadb_dump(
+    mariadb_dump, open_stream, filename, compression_ext, databases, additional_options
+):
+    """Run a mariadb-dump backup"""
+    try:
+        stream = open_stream(filename, "w")
+    except (IOError, OSError) as exc:
+        raise BackupError(
+            "Failed to open output stream %s: %s" % (filename + compression_ext, exc)
+        )
+    try:
+        mariadb_dump.run(databases, stream, additional_options=additional_options)
+    finally:
+        try:
+            stream.close()
+        except (IOError, OSError) as exc:
+            if exc.errno != errno.EPIPE:
+                LOG.error("%s", str(exc))
+                raise BackupError(str(exc))
+
+
+def write_manifest(schema, open_stream, ext):
+    """Write real database names => encoded names to MANIFEST.txt"""
+    manifest_fileobj = open_stream("MANIFEST.txt", "w", method="none")
+
+    try:
+        for database in schema.databases:
+            if database.excluded:
+                continue
+            name = database.name
+            encoded_name = encode(name)
+            line = "%s %s\n" % (name, encoded_name + ".sql" + ext)
+            manifest_fileobj.write(line)
+    finally:
+        manifest_fileobj.close()
+        LOG.info("Wrote backup manifest %s", manifest_fileobj.name)
+
+
+def mariadb_dump_lock_option(lock_method, databases):
+    """Choose the mariadb-dump option to use for locking
+    given the requested lock-method and the set of databases to
+    be backed up
+    """
+    if lock_method == "auto-detect":
+        return mariadb_dump_autodetect_lock(databases)
+
+    valid_methods = {
+        "flush-lock": "--lock-all-tables",
+        "lock-tables": "--lock-tables",
+        "single-transaction": "--single-transaction",
+        "none": "--skip-lock-tables",
+    }
+    try:
+        return valid_methods[lock_method]
+    except KeyError:
+        raise BackupError("Invalid mariadb-dump lock method %r" % lock_method)
+
+
+def mariadb_dump_autodetect_lock(databases):
+    """Auto-detect if we can do a transactional or
+    non-transactional backup with mariadb-dump
+    """
+
+    if databases == ALL_DATABASES:
+        return "--lock-all-tables"
+
+    for database in databases:
+        if database.excluded:
+            continue
+        for table in database.tables:
+            if table.excluded:
+                continue
+            if not table.is_transactional:
+                return "--lock-tables"
+
+    return "--single-transaction"

--- a/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/command.py
+++ b/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/command.py
@@ -1,0 +1,227 @@
+"""mariadb-dump support"""
+
+import errno
+import logging
+import os
+import re
+import subprocess
+from tempfile import TemporaryFile
+
+LOG = logging.getLogger(__name__)
+
+ALL_DATABASES = object()
+
+OPTION_ARG_CRE = re.compile(r"^(--[^=]+)(?:=(.+))?$", re.UNICODE)
+
+CHECK_VERSION_OPTIONS = {
+    "--order-by-size": (10, 9, 1),
+    "--dump-history": (10, 11, 0),
+}
+
+CHECK_OPTION_ARG_PATTERNS = {
+    "--max-allowed-packet": r"\w",
+    "--default-character-set": r"\w",
+    "--master-data": r"^[12]$",
+}
+
+
+class MariaDBDumpError(Exception):
+    """Excepton class for MariaDump errors"""
+
+
+class MariaDBDumpOptionError(Exception):
+    """Exception class for MariaDB Option validation"""
+
+
+class MariaDBDump(object):
+    """mariadb-dump command runner"""
+
+    @classmethod
+    def get_version(cls, command):
+        """Return the version of the given mariadb-dump command"""
+        args = [command, "--no-defaults", "--version"]
+        list2cmdline = subprocess.list2cmdline
+        cmdline = list2cmdline(args)
+        LOG.debug("Executing: %s", cmdline)
+        try:
+            process = subprocess.Popen(
+                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True
+            )
+            stdout, _ = process.communicate()
+        except OSError as exc:
+            if exc.errno == errno.ENOENT:
+                raise MariaDBDumpError("'%s' does not exist" % command)
+            raise MariaDBDumpError(
+                "Error[%d:%s] when trying to run '%s'"
+                % (exc.errno, errno.errorcode[exc.errno], command)
+            )
+
+        if process.returncode != 0:
+            LOG.error("%s exited with non-zero status[%d]", cmdline, process.returncode)
+            for line in stdout.splitlines():
+                LOG.error("! %s", line)
+        try:
+            return tuple(
+                (
+                    int(digit)
+                    for digit in re.search(
+                        r"(\d+)[.](\d+)[.](\d+)", stdout.decode("utf-8")
+                    ).groups()
+                )
+            )
+        except AttributeError:
+            LOG.debug("%s provided output %r", cmdline, stdout)
+            raise MariaDBDumpError(
+                "Failed to determine mariadb-dump version for %s" % command
+            )
+
+    def __init__(
+        self,
+        defaults_file,
+        cmd_path="mariadb-dump",
+        extra_defaults=False,
+        mock_env=None,
+    ):
+        if not os.path.exists(cmd_path):
+            raise MariaDBDumpError("'%s' does not exist" % cmd_path)
+        self.cmd_path = cmd_path
+        self.defaults_file = defaults_file
+        self.extra_defaults = extra_defaults
+        self._version = self.get_version(cmd_path)
+        self.options = []
+        self.mock_env = mock_env
+
+    @property
+    def version(self):
+        """Return the version tuple (major, minor, patch)"""
+        return self._version
+
+    @property
+    def version_str(self):
+        """Return the version as a string (e.g. '10.5.8')"""
+        return ".".join(str(d) for d in self._version)
+
+    def set_options_from_config(self, config, bin_log_active=False):
+        """Set options from the config dictionary."""
+        config_options = []
+        # Boolean options
+        for key, option in [
+            ("flush-logs", "--flush-logs"),
+            ("flush-privileges", "--flush-privileges"),
+            ("dump-routines", "--routines"),
+            ("dump-events", "--events"),
+            ("dump-history", "--dump-history"),
+            ("order-by-size", "--order-by-size"),
+        ]:
+            if config[key]:
+                config_options.append(option)
+
+        # Handle max-allowed-packet
+        if config["max-allowed-packet"]:
+            config_options.append(
+                f"--max-allowed-packet={config['max-allowed-packet']}"
+            )
+
+        # Handle bin-log-position
+        if config["bin-log-position"]:
+            if not bin_log_active:
+                raise MariaDBDumpError(
+                    "bin-log-position requested but bin-log on server not active"
+                )
+            config_options.append("--master-data=2")
+
+        # Add additional options and validate
+        for option in config_options + config["additional-options"]:
+            if not option:
+                continue
+            if option in self.options:
+                LOG.warning("mariadb-dump option '%s' already requested.", option)
+            self.options.append(option)
+            try:
+                self._check_option(option, config["additional-options"])
+                LOG.info("Using mariadb-dump option %s", option)
+            except MariaDBDumpOptionError as exc:
+                LOG.warning(str(exc))
+
+    def _check_option(self, option, additional_options):
+        """Checks and validates certain options we care about"""
+        try:
+            option, arg = OPTION_ARG_CRE.search(option).groups()
+        except AttributeError:
+            raise MariaDBDumpOptionError("Unparseable option '%s'" % option)
+
+        if option in additional_options:
+            raise MariaDBDumpOptionError("User supplied option '%s'" % option)
+
+        required_version = CHECK_VERSION_OPTIONS.get(option)
+        if required_version and self.version < required_version:
+            raise MariaDBDumpOptionError(
+                "Option %r requires minimum version %s"
+                % (
+                    option,
+                    ".".join(str(d) for d in required_version),
+                ),
+            )
+
+        pattern = CHECK_OPTION_ARG_PATTERNS.get(option)
+        if pattern and not re.match(pattern, arg):
+            if option == "--master-data":
+                raise MariaDBDumpOptionError(
+                    "Argument to --master-data must be 1 or 2 not %r" % arg
+                )
+            raise MariaDBDumpOptionError(
+                "Invalid argument to option '%s': %r" % (option, arg)
+            )
+
+    def run(self, databases, stream, additional_options=None):
+        """Run mariadb-dump with the options configured on this instance"""
+        if not hasattr(stream, "fileno"):
+            raise MariaDBDumpError("Invalid output stream")
+
+        if not databases:
+            raise MariaDBDumpError("No databases specified to backup")
+
+        # Build the command arguments
+        args = [self.cmd_path]
+
+        # Add defaults file if specified
+        if self.defaults_file:
+            prefix = "defaults-extra" if self.extra_defaults else "defaults"
+            args.append(f"--{prefix}-file={self.defaults_file}")
+
+        # Add options derived from config
+        args.extend(self.options)
+
+        # Add additional options when called from base.start()
+        if additional_options:
+            args.extend(additional_options)
+
+        # Handle database arguments
+        if databases is ALL_DATABASES:
+            args.append("--all-databases")
+        else:
+            args.extend(["--databases"] if len(databases) > 1 else [])
+            args.extend(databases)
+
+        if self.mock_env:
+            LOG.info("Dry Run: %s", subprocess.list2cmdline(args))
+            popen = self.mock_env.mocked_popen
+        else:
+            LOG.info("Executing: %s", subprocess.list2cmdline(args))
+            popen = subprocess.Popen
+        errlog = TemporaryFile()
+        pid = popen(
+            args, stdout=stream.fileno(), stderr=errlog.fileno(), close_fds=True
+        )
+        status = pid.wait()
+        try:
+            errlog.flush()
+            errlog.seek(0)
+            for line in errlog:
+                LOG.error("%s[%d]: %s", self.cmd_path, pid.pid, line.rstrip())
+        finally:
+            errlog.close()
+        if status != 0:
+            raise MariaDBDumpError(
+                "mariadb-dump exited with non-zero status %d" % pid.returncode
+            )

--- a/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/mock/__init__.py
+++ b/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/mock/__init__.py
@@ -1,0 +1,73 @@
+"""Use Mock to preform dry run"""
+
+import os
+
+# For 2.7 or newer use unittest.mock
+try:
+    from unittest.mock import ANY, MagicMock
+except ImportError:
+    from mock import ANY, MagicMock
+
+__all__ = ["MockEnvironment"]
+
+
+class MockPopen(object):
+    """
+    mock object to return to subclass.Popen
+    """
+
+    def __init__(self):
+        self.pid = -1
+        self.returncode = 0
+        null = open(os.devnull, "w")
+        self.stdin = null
+        self.stderr = null
+        self.stdout = null
+
+    @staticmethod
+    def wait():
+        """
+        Mock waiting for process to complete
+        """
+        return 0
+
+    @staticmethod
+    def poll():
+        """
+        Mock polling process status
+        """
+        return 0
+
+
+class MockEnvironment(object):
+    """
+    Setup environement for dry-run
+    """
+
+    def __init__(self):
+        """
+        Create Mock object
+        """
+        self.mocker = MagicMock()
+
+    def replace_environment(self):
+        """
+        Redirect everything to mock
+        """
+        self.mocker.replay()
+
+    def restore_environment(self):
+        """
+        Return to normal environment
+        """
+        self.mocker.restore()
+        self.mocker.verify()
+
+    # pylint: disable=unused-argument
+    @staticmethod
+    def mocked_popen(*args, **kwargs):
+        """
+        Replace subprocess.peopen so dry-run doesn't
+        actually call mysqldump
+        """
+        return MockPopen()

--- a/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/plugin.py
+++ b/plugins/holland.backup.mariadb_dump/holland/backup/mariadb_dump/plugin.py
@@ -1,0 +1,481 @@
+"""Command Line Interface"""
+
+import codecs
+import logging
+import os
+from copy import deepcopy
+
+from holland.backup.mariadb_dump.base import start
+from holland.backup.mariadb_dump.command import MariaDBDump, MariaDBDumpError
+from holland.backup.mariadb_dump.mock import MockEnvironment
+from holland.core.backup import BackupError
+from holland.lib.compression import (
+    COMPRESSION_CONFIG_STRING,
+    lookup_compression,
+    open_stream,
+)
+from holland.lib.mysql import (
+    DatabaseIterator,
+    MetadataTableIterator,
+    MySQLError,
+    MySQLSchema,
+    SimpleTableIterator,
+    connect,
+    exclude_glob,
+    exclude_glob_qualified,
+    include_glob,
+    include_glob_qualified,
+)
+from holland.lib.mysql.client.base import MYSQL_CLIENT_CONFIG_STRING
+from holland.lib.mysql.option import build_mysql_config, write_options
+from holland.lib.mysql.util import parse_size
+from holland.lib.util import get_cmd_path
+
+LOG = logging.getLogger(__name__)
+
+# We validate our config against the following spec
+CONFIGSPEC = (
+    """
+[mariadb-dump]
+extra-defaults      = boolean(default=no)
+executable          = string(default=mariadb-dump)
+lock-method         = option('flush-lock', 'lock-tables', 'single-transaction', 'auto-detect', 'none', default='auto-detect') # pylint: disable=line-too-long
+databases           = force_list(default=list('*'))
+exclude-databases   = force_list(default=list())
+tables              = force_list(default=list("*"))
+exclude-tables      = force_list(default=list())
+engines             = force_list(default=list("*"))
+exclude-engines     = force_list(default=list())
+exclude-invalid-views = boolean(default=no)
+flush-logs          = boolean(default=no)
+flush-privileges    = boolean(default=yes)
+dump-routines       = boolean(default=yes)
+dump-events         = boolean(default=yes)
+dump-history        = boolean(default=no)
+order-by-size       = boolean(default=no)
+stop-slave          = boolean(default=no)
+bin-log-position    = boolean(default=no)
+max-allowed-packet  = string(default=128M)
+file-per-database   = boolean(default=yes)
+arg-per-database    = string(default={})
+additional-options  = force_list(default=list())
+estimate-method     = string(default='plugin')
+"""
+    + MYSQL_CLIENT_CONFIG_STRING
+    + COMPRESSION_CONFIG_STRING
+)
+
+CONFIGSPEC = CONFIGSPEC.splitlines()
+
+
+class MariaDBDumpPlugin(object):
+    """mariadb-dump Backup Plugin interface for Holland"""
+
+    CONFIGSPEC = CONFIGSPEC
+
+    def __init__(self, name, config, target_directory, dry_run=False):
+        self.name = name
+        self.config = config
+        self.target_directory = target_directory
+        self.dry_run = dry_run
+        self.config.validate_config(self.CONFIGSPEC)  # -> ValidationError
+
+        # Setup a discovery shell to find schema items
+        # This will iterate over items during the estimate
+        # or backup phase, which will call schema.refresh()
+        self.schema = MySQLSchema()
+        config = self.config["mariadb-dump"]
+        self.schema.add_database_filter(include_glob(*config["databases"]))
+        self.schema.add_database_filter(exclude_glob(*config["exclude-databases"]))
+
+        self.schema.add_table_filter(include_glob_qualified(*config["tables"]))
+        self.schema.add_table_filter(exclude_glob_qualified(*config["exclude-tables"]))
+        self.schema.add_engine_filter(include_glob(*config["engines"]))
+        self.schema.add_engine_filter(exclude_glob(*config["exclude-engines"]))
+
+        self.mysql_config = build_mysql_config(self.config["mysql:client"])
+        self.client = connect(self.mysql_config["client"])
+
+        self.mock_env = None
+
+    def estimate_backup_size(self):
+        """Estimate the size of the backup this plugin will generate"""
+
+        LOG.info("Estimating size of mariadb-dump backup")
+        estimate_method = self.config["mariadb-dump"]["estimate-method"]
+
+        if estimate_method.startswith("const:"):
+            try:
+                return parse_size(estimate_method[6:])
+            except ValueError as exc:
+                raise BackupError(str(exc))
+
+        if estimate_method != "plugin":
+            raise BackupError("Invalid estimate-method '%s'" % estimate_method)
+
+        try:
+            db_iter = DatabaseIterator(self.client)
+            tbl_iter = MetadataTableIterator(self.client)
+            try:
+                self.client.connect()
+            except Exception as ex:
+                LOG.error("Failed to connect to database")
+                LOG.debug("%s", ex)
+                raise BackupError("MariaDB Error %s" % ex)
+            try:
+                self.schema.refresh(db_iter=db_iter, tbl_iter=tbl_iter)
+            except MySQLError as exc:
+                LOG.error("Failed to estimate backup size")
+                LOG.debug("[%d] %s", *exc.args)
+                raise BackupError("MariaDB Error [%d] %s" % exc.args)
+            return float(sum([db.size for db in self.schema.databases]))
+        finally:
+            self.client.disconnect()
+
+    def _fast_refresh_schema(self):
+        # determine if we can skip expensive table metadata lookups entirely
+        # and just worry about finding database names
+        # However, with lock-method=auto-detect we must look at table engines
+        # to determine what lock method to use
+        config = self.config["mariadb-dump"]
+        fast_iterate = (
+            config["lock-method"] != "auto-detect"
+            and not config["exclude-invalid-views"]
+        )
+
+        try:
+            db_iter = DatabaseIterator(self.client)
+            tbl_iter = SimpleTableIterator(self.client, record_engines=True)
+            try:
+                self.client.connect()
+                self.schema.refresh(
+                    db_iter=db_iter, tbl_iter=tbl_iter, fast_iterate=fast_iterate
+                )
+            except MySQLError as exc:
+                LOG.debug("MariaDB error [%d] %s", exc_info=True, *exc.args)
+                raise BackupError("MariaDB Error [%d] %s" % exc.args)
+        finally:
+            self.client.disconnect()
+
+    def backup(self):
+        """Run a MariaDB backup"""
+        if self.schema.timestamp is None:
+            self._fast_refresh_schema()
+
+        try:
+            self.client = connect(self.mysql_config["client"])
+        except Exception as ex:
+            LOG.debug("%s", ex)
+            raise BackupError("Failed connecting to database'")
+
+        if self.dry_run:
+            self.mock_env = MockEnvironment()
+            self.mock_env.replace_environment()
+            LOG.info("Running in dry-run mode.")
+            status = self.client.show_databases()
+            if not status:
+                raise BackupError("Failed to run 'show databases'")
+        try:
+            if self.config["mariadb-dump"]["stop-slave"]:
+                slave_status = self.client.show_slave_status()
+                if not slave_status:
+                    raise BackupError(
+                        "stop-slave enabled, but 'show slave status' failed"
+                    )
+                if slave_status and slave_status["slave_sql_running"] != "Yes":
+                    raise BackupError(
+                        "stop-slave enabled, but replication is not running"
+                    )
+                if not self.dry_run:
+                    _stop_slave(self.client, self.config)
+            elif self.config["mariadb-dump"]["bin-log-position"]:
+                self.config["mysql:replication"] = {}
+                repl_cfg = self.config["mysql:replication"]
+                try:
+                    master_info = self.client.show_master_status()
+                    if master_info:
+                        repl_cfg["master_log_file"] = master_info["file"]
+                        repl_cfg["master_log_pos"] = master_info["position"]
+                except MySQLError as exc:
+                    raise BackupError(
+                        "Failed to acquire master status [%d] %s" % exc.args
+                    )
+            self._backup()
+        finally:
+            if (
+                self.config["mariadb-dump"]["stop-slave"]
+                and "mysql:replication" in self.config
+            ):
+                _start_slave(self.client, self.config["mysql:replication"])
+            if self.mock_env:
+                self.mock_env.restore_environment()
+
+    def _backup(self):
+        """Real backup method.  May raise BackupError exceptions"""
+        config = self.config["mariadb-dump"]
+        # setup defaults_file with ignore-table exclusions
+        defaults_file = os.path.join(self.target_directory, "my.cnf")
+        write_options(self.mysql_config, defaults_file)
+        if config["exclude-invalid-views"]:
+            LOG.info("* Finding and excluding invalid views...")
+            definitions_path = os.path.join(self.target_directory, "invalid_views.sql")
+            exclude_invalid_views(self.schema, self.client, definitions_path)
+        add_exclusions(self.schema, defaults_file)
+        # find the path to the mariadb-dump command
+        cmd_path = get_cmd_path(config["executable"])
+        LOG.info("Using mariadb-dump executable: %s", cmd_path)
+        # setup the mariadb-dump environment
+        extra_defaults = config["extra-defaults"]
+        try:
+            mariadb_dump = MariaDBDump(
+                defaults_file,
+                cmd_path=cmd_path,
+                extra_defaults=extra_defaults,
+                mock_env=self.mock_env,
+            )
+        except MariaDBDumpError as exc:
+            raise BackupError(str(exc))
+        except Exception as ex:  # pylint: disable=W0703
+            LOG.warning(ex)
+        LOG.info("mariadb-dump version %s", mariadb_dump.version_str)
+        bin_log_active = self.client.show_variable("log_bin") == "ON"
+        try:
+            mariadb_dump.set_options_from_config(config, bin_log_active=bin_log_active)
+        except MariaDBDumpError as exc:
+            raise BackupError(str(exc))
+
+        os.mkdir(os.path.join(self.target_directory, "backup_data"))
+
+        if (
+            self.config["compression"]["method"] != "none"
+            and self.config["compression"]["level"] > 0
+        ):
+            try:
+                _, ext = lookup_compression(self.config["compression"]["method"])
+            except OSError as exc:
+                raise BackupError(
+                    "Unable to load compression method '%s': %s"
+                    % (self.config["compression"]["method"], exc)
+                )
+            LOG.info(
+                "Using %s compression level %d with args %s",
+                self.config["compression"]["method"],
+                self.config["compression"]["level"],
+                self.config["compression"]["options"],
+            )
+        else:
+            LOG.info("Not compressing mariadb-dump output")
+            ext = ""
+
+        try:
+            start(
+                mariadb_dump=mariadb_dump,
+                schema=self.schema,
+                lock_method=config["lock-method"],
+                file_per_database=config["file-per-database"],
+                open_stream=self._open_stream,
+                compression_ext=ext,
+                arg_per_database=config["arg-per-database"],
+            )
+        except MariaDBDumpError as exc:
+            raise BackupError(str(exc))
+
+    def _open_stream(self, path, mode, method=None):
+        """Open a stream through the holland compression api, relative to
+        this instance's target directory
+        """
+        path = str(os.path.join(self.target_directory, "backup_data", path))
+        config = deepcopy(self.config["compression"])
+        if method:
+            config["method"] = method
+        stream = open_stream(path, mode, **config)
+        return stream
+
+
+def _stop_slave(client, config):
+    """Stop MariaDB replication"""
+    try:
+        client.stop_slave(sql_thread_only=True)
+        LOG.info("Stopped slave")
+        config["mysql:replication"] = {}
+        repl_cfg = config["mysql:replication"]
+    except MySQLError as exc:
+        raise BackupError("Failed to stop slave[%d]: %s" % exc.args)
+
+    try:
+        slave_info = client.show_slave_status()
+        if slave_info:
+            # update config with replication info
+            log_file = slave_info["relay_master_log_file"]
+            log_pos = slave_info["exec_master_log_pos"]
+            repl_cfg["slave_master_log_file"] = log_file
+            repl_cfg["slave_master_log_pos"] = log_pos
+    except MySQLError as exc:
+        raise BackupError("Failed to acquire slave status[%d]: %s" % exc.args)
+    try:
+        master_info = client.show_master_status()
+        if master_info:
+            repl_cfg["master_log_file"] = master_info["file"]
+            repl_cfg["master_log_pos"] = master_info["position"]
+    except MySQLError as exc:
+        raise BackupError("Failed to acquire master status [%d] %s" % exc.args)
+
+    LOG.info("MariaDB Replication has been stopped.")
+
+
+def _start_slave(client, config=None):
+    """Start MariaDB replication"""
+
+    # Skip sanity check on slave coords if we didn't actually record any coords
+    # This might happen if mariadb goes away between STOP SLAVE and SHOW SLAVE
+    # STATUS.
+    if config:
+        try:
+            slave_info = client.show_slave_status()
+            if (
+                slave_info
+                and slave_info["exec_master_log_pos"] != config["slave_master_log_pos"]
+            ):
+                LOG.warning(
+                    "Sanity check on slave status failed.  "
+                    "Previously recorded %s:%d but currently found"
+                    " %s:%d",
+                    config["slave_master_log_file"],
+                    config["slave_master_log_pos"],
+                    slave_info["relay_master_log_file"],
+                    slave_info["exec_master_log_pos"],
+                )
+                LOG.warning("ALERT! Slave position changed during backup!")
+        except MySQLError as exc:
+            LOG.warning("Failed to sanity check replication[%d]: %s", *exc.args)
+
+        try:
+            master_info = client.show_master_status()
+            if master_info and master_info["position"] != config["master_log_pos"]:
+                LOG.warning(
+                    "Sanity check on master status failed.  "
+                    "Previously recorded %s:%s but currently found"
+                    " %s:%s",
+                    config["master_log_file"],
+                    config["master_log_pos"],
+                    master_info["file"],
+                    master_info["position"],
+                )
+                LOG.warning("ALERT! Binary log position changed during backup!")
+        except MySQLError as exc:
+            LOG.warning("Failed to sanity check master status. [%d] %s", *exc.args)
+
+    try:
+        client.start_slave()
+        LOG.info("Restarted slave")
+    except MySQLError as exc:
+        raise BackupError("Failed to restart slave [%d] %s" % exc.args)
+
+
+def exclude_invalid_views(schema, client, definitions_file):
+    """Flag invalid MariaDB views as excluded to skip them during a mariadb-dump"""
+    LOG.info("* Invalid and excluded views will be saved to %s", definitions_file)
+    cursor = client.cursor()
+
+    invalid_views = (
+        "--\n-- DDL of Invalid Views\n-- Created automatically by Holland\n--\n"
+    )
+
+    for schema_db in schema.databases:
+        if schema_db.excluded:
+            continue
+        for table in schema_db.tables:
+            if table.excluded:
+                continue
+            if table.engine != "view":
+                continue
+            LOG.debug("Testing view %s.%s", schema_db.name, table.name)
+            invalid_view = False
+            try:
+                cursor.execute(
+                    "SHOW FIELDS FROM `%s`.`%s`" % (schema_db.name, table.name)
+                )
+                # check for missing definers that would bork
+                # lock-tables
+                for _, error_code, msg in client.show_warnings():
+                    if error_code == 1449:  # ER_NO_SUCH_USER
+                        raise MySQLError(error_code, msg)
+            except MySQLError as exc:
+                # 1356 = View references invalid table(s)...
+                if exc.args[0] in (1356, 1142, 1143, 1449, 1267, 1271):
+                    invalid_view = True
+                else:
+                    LOG.error(
+                        "Unexpected error when checking invalid view %s.%s: [%d] %s",
+                        schema_db.name,
+                        table.name,
+                        *exc.args
+                    )
+                    raise BackupError("[%d] %s" % exc.args)
+            if invalid_view:
+                LOG.warning(
+                    "* Excluding invalid view `%s`.`%s`", schema_db.name, table.name
+                )
+                table.excluded = True
+                view_definition = client.show_create_view(
+                    schema_db.name, table.name, use_information_schema=True
+                )
+                if view_definition is None:
+                    LOG.error(
+                        "!!! Failed to retrieve view definition for `%s`.`%s`",
+                        schema_db.name,
+                        table.name,
+                    )
+                    LOG.warning(
+                        "!!! View definition for `%s`.`%s` will not be included in this backup",
+                        schema_db.name,
+                        table.name,
+                    )
+                    continue
+
+                LOG.info(
+                    "* Saving view definition for `%s`.`%s`",
+                    schema_db.name,
+                    table.name,
+                )
+                invalid_views = (
+                    invalid_views
+                    + "--\n-- Current View: `%s`.`%s`\n--\n%s;\n"
+                    % (
+                        schema_db.name,
+                        table.name,
+                        view_definition,
+                    )
+                )
+    with open(definitions_file, "w") as sqlf:
+        sqlf.write(invalid_views)
+
+
+def add_exclusions(schema, config):
+    """Given a MySQLSchema add --ignore-table options in a [mariadb-dump]
+    section for any excluded tables.
+
+    """
+
+    exclusions = []
+    for schema_db in schema.databases:
+        if schema_db.excluded:
+            continue
+        for table in schema_db.tables:
+            if table.excluded:
+                LOG.info("Excluding table %s.%s", table.database, table.name)
+                exclusions.append("ignore-table = " + table.database + "." + table.name)
+
+    if not exclusions:
+        return
+
+    try:
+        my_cnf = codecs.open(config, "a", "utf8")
+        print(file=my_cnf)
+        print("[mariadb-dump]", file=my_cnf)
+        for excl in exclusions:
+            print(excl, file=my_cnf)
+        my_cnf.close()
+    except IOError:
+        LOG.error("Failed to write ignore-table exclusions to %s", config)
+        raise

--- a/plugins/holland.backup.mariadb_dump/setup.cfg
+++ b/plugins/holland.backup.mariadb_dump/setup.cfg
@@ -1,0 +1,6 @@
+[egg_info]
+tag_svn_revision = true
+
+[nosetests]
+with-coverage=1
+cover-package=holland.backup.mariadb_dump

--- a/plugins/holland.backup.mariadb_dump/setup.py
+++ b/plugins/holland.backup.mariadb_dump/setup.py
@@ -1,0 +1,31 @@
+from setuptools import find_packages, setup
+
+version = "1.2.12"
+
+setup(
+    name="holland.backup.mariadb_dump",
+    version=version,
+    description="maria-dump Backup/Restore Plugins",
+    long_description="""\
+      Plugin support to provide backup and restore functionality
+      through maria-dump backups
+      """,
+    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords="",
+    author="Rackspace",
+    author_email="holland-devel@googlegroups.com",
+    url="http://hollandbackup.org",
+    license="GNU GPLv2",
+    packages=find_packages(exclude=["ez_setup", "examples", "tests", "tests.*"]),
+    include_package_data=True,
+    zip_safe=True,
+    test_suite="tests",
+    tests_require=["holland >= 0.9.6"],
+    install_requires=[],
+    extras_require={"mysql": "holland.lib.mysql", "common": "holland.lib.common"},
+    entry_points="""
+      [holland.backup]
+      mariadb-dump = holland.backup.mariadb_dump:Provider [mysql, common]
+      """,
+    namespace_packages=["holland", "holland.backup"],
+)

--- a/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
+++ b/plugins/holland.backup.mysqldump/holland/backup/mysqldump/plugin.py
@@ -3,7 +3,6 @@
 import codecs
 import logging
 import os
-import re
 import textwrap
 from copy import deepcopy
 
@@ -30,6 +29,7 @@ from holland.lib.mysql import (
 )
 from holland.lib.mysql.client.base import MYSQL_CLIENT_CONFIG_STRING
 from holland.lib.mysql.option import build_mysql_config, write_options
+from holland.lib.mysql.util import parse_size
 
 LOG = logging.getLogger(__name__)
 
@@ -554,29 +554,3 @@ def add_exclusions(schema, config):
     except IOError:
         LOG.error("Failed to write ignore-table exclusions to %s", config)
         raise
-
-
-def parse_size(units_string):
-    """Parse a MySQL-like size string into bytes
-
-    >> parse_size('4G')
-    4294967296
-    """
-
-    units_string = str(units_string)
-
-    units = "kKmMgGtTpPeE"
-
-    match = re.match(r"^(\d+(?:[.]\d+)?)([%s]?)$" % units, units_string)
-    if not match:
-        raise ValueError("Invalid constant size syntax %r" % units_string)
-    number, unit = match.groups()
-
-    if not unit:
-        return int(float(number))
-
-    unit = unit.upper()
-
-    exponent = "KMGTPE".find(unit)
-
-    return int(float(number) * 1024 ** (exponent + 1))

--- a/plugins/holland.lib.common/holland/lib/util.py
+++ b/plugins/holland.lib.common/holland/lib/util.py
@@ -2,7 +2,11 @@
 Helpful functions
 """
 
+import os
+import shutil
 from string import Template
+
+from holland.core.backup import BackupError
 
 
 def parse_arguments(arguments, **kwargs):
@@ -14,3 +18,46 @@ def parse_arguments(arguments, **kwargs):
     ret = Template(arguments).safe_substitute(**kwargs)
     ret = ret.split(" ")
     return ret
+
+
+def get_cmd_path(cmd, mode=os.F_OK | os.X_OK, path=None, raise_when_not_found=True):
+    """Find the full path to an executable command.
+
+    Args:
+        cmd (str): The command to find. If an absolute path is provided, it will be
+            checked directly. Otherwise, the command name will be searched for
+            in the provided PATH or environment PATH.
+        mode (int, optional): The access mode to check. Defaults to os.F_OK | os.X_OK.
+        path (str or list, optional): PATH string or list of directories to search.
+            If not provided, uses the environment PATH.
+        raise_when_not_found (bool, optional): If True, raises BackupError when command
+            is not found. If False, returns None instead.
+
+    Returns:
+        str or None: The full path to the command if found. Returns None if the command
+            is not found and raise_when_not_found is False.
+
+    Raises:
+        BackupError: If the command is not found and raise_when_not_found is True.
+    """
+    # If path is a list, convert it to a PATH string
+    if path and isinstance(path, list):
+        path = os.pathsep.join(path)
+    # Fall back to environment PATH if no path is provided
+    path = path or os.environ.get("PATH", "")
+    try:
+        cmd_path = shutil.which(cmd, mode=mode, path=path)
+    except AttributeError:
+        # shutil.which was added in python 3.3
+        # Check if we were given an absolute path
+        if os.path.isabs(cmd):
+            cmd_path = cmd if os.access(cmd, mode) else None
+        else:
+            for path_dir in [p for p in path.split(os.pathsep) if p]:
+                test_path = os.path.join(path_dir, cmd)
+                if os.access(test_path, mode):
+                    cmd_path = test_path
+                    break
+    if not cmd_path and raise_when_not_found:
+        raise BackupError("Failed to find '%s' in PATH: %s" % (cmd, path))
+    return cmd_path

--- a/plugins/holland.lib.mysql/holland/lib/mysql/util.py
+++ b/plugins/holland.lib.mysql/holland/lib/mysql/util.py
@@ -1,0 +1,50 @@
+"""
+MySQL related utility functions
+"""
+
+import re
+
+
+def parse_size(units_string):
+    """Parse a MySQL-like size string into bytes.
+
+    This function converts a human-readable size string (like '4G' for 4 gigabytes) into
+    its equivalent number of bytes. It supports various unit suffixes (K, M, G, T, P, E)
+    and their lowercase variants.
+
+    Args:
+        units_string (str): A string representing a size with an optional unit suffix.
+            Examples: '4G', '1024M', '1.5T'
+
+    Returns:
+        int: The number of bytes represented by the input string.
+
+    Raises:
+        ValueError: If the input string does not match the expected format.
+
+    Examples:
+        >>> parse_size('4G')
+        4294967296
+        >>> parse_size('1024M')
+        1073741824
+        >>> parse_size('1.5T')
+        1649267441664
+    """
+
+    units_string = str(units_string)
+
+    units = "kKmMgGtTpPeE"
+
+    match = re.match(r"^(\d+(?:[.]\d+)?)([%s]?)$" % units, units_string)
+    if not match:
+        raise ValueError("Invalid constant size syntax %r" % units_string)
+    number, unit = match.groups()
+
+    if not unit:
+        return int(float(number))
+
+    unit = unit.upper()
+
+    exponent = "KMGTPE".find(unit)
+
+    return int(float(number) * 1024 ** (exponent + 1))


### PR DESCRIPTION

Adds a new mariadb-dump plugin to facilitate the diversion of mariabd-dump from mysqldump occurring upstream. This started off largely as a copy and paste of the mysqldump plugin and some search and replace fun. It does have some diversions from mysqldump that I'm open to changing.

Changes from mysqldump:
- The backupset provider conf for this plugin includes all options we expose via the configspec.
- The configspec for mariadb-dump uses a generic `executable` setting that defaults to `mariadb-dump` and uses a new `get_cmd_path` method helper that ensure we properly search the holland defined environment PATH. This value can also be set to an absolute path. This also allows for the executable to be named anything so that a user could potentially even wrap the mariadb-dump call if needed for some reason. The existing `which` helper has some inconsistent behavior differences when not using `shutil.which` that should be addressed with the new helper. Plugins should migrate to using this new helper.
- The `command.py` in mysqldump was overly complicated and didn't provide us much benefit. I've simplified that interface a bit so that the validation made more sense and was straight forward. Any option not exposed via the configspec and is not something that we are providing some validation is not anything we need to care about in code: https://github.com/holland-backup/holland/blob/master/plugins/holland.backup.mysqldump/holland/backup/mysqldump/command.py#L100-L136. 
- I've removed the `info` helper for this plugin when running `holland list-backups -v`. Not all plugins provide it and the existing verbosity seems sufficient.

General Bug fixes include:

- `holland list-backups -v` does not properly template the values in it's output due to the hyphens used in the template string. This has been fixed.
- `holland list-backups -v` also complained about `failed` being an unknown option it found in the config read from the backup. We defined `failed-backup` in the core configspec - but were maintaining state with the value `failed`. I changed `failed-backup` to `failed` to match what we were actually using in code.
- The existing mysqldump plugin has this code path of only adding `flush-logs` to the last database in the list under certain conditions:
https://github.com/holland-backup/holland/blob/master/plugins/holland.backup.mysqldump/holland/backup/mysqldump/base.py#L46-L50
However, this condition will never be hit as enumerate starts at 0 and checking the list length for equality will never be true. I fixed the logic in this mariadb-dump plugin but need to confirm its a bug since since no one has mentioned anything about it.

Setting this to draft for now as I continue to review these changes.