### PR TITLE
Bump Holland version to 1.3.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,7 +206,7 @@ pipeline {
         apt-get -yq remove dbconfig-mysql
 
         # Install MariaDB 10.11
-        curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version=mariadb-10.11 && \
+        curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --skip-os-eol-check --mariadb-server-version=mariadb-10.11 && \
         apt-get update && \
         apt-get -yq install mariadb-server mariadb-client
 

--- a/config/providers/mysqlsh-dump-instance.conf
+++ b/config/providers/mysqlsh-dump-instance.conf
@@ -23,10 +23,10 @@ extra-defaults = no
 # 1=none, 2=internal, 3=error, 4=warning, 5=info, 6=debug, 7=debug2, or 8=debug3.
 log-level = 5
 
-## Whether to stop the slave before commencing with the backup.up.
+## Whether to stop the slave before commencing with the backup.
 stop-slave = no
 
-# Additional options to pass to the mysqlsh command. When specificying an
+# Additional options to pass to the mysqlsh command. When specifying an
 # additional named argument that takes a list of values. You will want to
 # define the key repeatedly for each item in the list.
 # e.g --compatibility=strip_definers, --compatibility=strip_restricted_grants
@@ -56,7 +56,7 @@ compression = zstd
 chunking = yes
 
 # The approximate size of each chunk when chunking is enabled. Requires chunking to be enabled
-# in the backupset config. This options is always specified when holland executes mysqlsh
+# in the backupset config. This option is always specified when holland executes mysqlsh
 # and chunking is enabled.
 bytes-per-chunk = 64M
 

--- a/config/providers/mysqlsh-dump-schemas.conf
+++ b/config/providers/mysqlsh-dump-schemas.conf
@@ -23,10 +23,10 @@ extra-defaults = no
 # 1=none, 2=internal, 3=error, 4=warning, 5=info, 6=debug, 7=debug2, or 8=debug3.
 log-level = 5
 
-## Whether to stop the slave before commencing with the backup.up.
+## Whether to stop the slave before commencing with the backup.
 stop-slave = no
 
-# Additional options to pass to the mysqlsh command. When specificying an
+# Additional options to pass to the mysqlsh command. When specifying an
 # additional named argument that takes a list of values. You will want to
 # define the key repeatedly for each item in the list.
 # e.g --compatibility=strip_definers, --compatibility=strip_restricted_grants
@@ -56,7 +56,7 @@ compression = zstd
 chunking = yes
 
 # The approximate size of each chunk when chunking is enabled. Requires chunking to be enabled
-# in the backupset config. This options is always specified when holland executes mysqlsh
+# in the backupset config. This option is always specified when holland executes mysqlsh
 # and chunking is enabled.
 bytes-per-chunk = 64M
 

--- a/contrib/holland-commvault/setup.py
+++ b/contrib/holland-commvault/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland_commvault",

--- a/plugins/holland.backup.command/setup.py
+++ b/plugins/holland.backup.command/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.command",

--- a/plugins/holland.backup.example/setup.py
+++ b/plugins/holland.backup.example/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.example",

--- a/plugins/holland.backup.mariabackup/setup.py
+++ b/plugins/holland.backup.mariabackup/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.mariabackup",

--- a/plugins/holland.backup.mariadb_dump/setup.py
+++ b/plugins/holland.backup.mariadb_dump/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.mariadb_dump",

--- a/plugins/holland.backup.mongodump/setup.py
+++ b/plugins/holland.backup.mongodump/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.mongodump",

--- a/plugins/holland.backup.mysql_lvm/setup.py
+++ b/plugins/holland.backup.mysql_lvm/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.mysql_lvm",

--- a/plugins/holland.backup.mysqldump/setup.py
+++ b/plugins/holland.backup.mysqldump/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.mysqldump",

--- a/plugins/holland.backup.mysqlsh/setup.py
+++ b/plugins/holland.backup.mysqlsh/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.mysqlsh",

--- a/plugins/holland.backup.pg_basebackup/setup.py
+++ b/plugins/holland.backup.pg_basebackup/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.pg_basebackup",

--- a/plugins/holland.backup.pgdump/setup.py
+++ b/plugins/holland.backup.pgdump/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.pgdump",

--- a/plugins/holland.backup.random/setup.py
+++ b/plugins/holland.backup.random/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.random",

--- a/plugins/holland.backup.sqlite/setup.py
+++ b/plugins/holland.backup.sqlite/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.sqlite",

--- a/plugins/holland.backup.tar/setup.py
+++ b/plugins/holland.backup.tar/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.tar",

--- a/plugins/holland.backup.xtrabackup/setup.py
+++ b/plugins/holland.backup.xtrabackup/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.backup.xtrabackup",

--- a/plugins/holland.lib.common/setup.py
+++ b/plugins/holland.lib.common/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.lib.common",

--- a/plugins/holland.lib.lvm/setup.py
+++ b/plugins/holland.lib.lvm/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland.lib.lvm",

--- a/plugins/holland.lib.mysql/setup.py
+++ b/plugins/holland.lib.mysql/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "1.2.12"
+version = "1.3.0"
 
 setup(
     name="holland",


### PR DESCRIPTION
- Bumps version to 1.3.0 for next release.
- Bumps docs submodule to latest for 1.3.0 release
- Fixes a few small typos I found in the new mysqlsh provider configs.
- Adds a `--skip-os-eol-checks` to mariadb repo setup which was causing the jenkins job to fail.